### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-gitops-test.yaml
+++ b/.github/workflows/ci-gitops-test.yaml
@@ -1,4 +1,6 @@
 name: CI - GitOps Test
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/reusable-workflows/security/code-scanning/29](https://github.com/devantler-tech/reusable-workflows/security/code-scanning/29)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs scripts, it likely only needs `contents: read`. The best practice is to add the `permissions` block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No changes to steps or job definitions are needed. Only the YAML file `.github/workflows/ci-gitops-test.yaml` needs to be edited, with the `permissions` block inserted after the `name:` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
