### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: 🔑 Get GitHub App Token


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/reusable-workflows/security/code-scanning/28](https://github.com/devantler-tech/reusable-workflows/security/code-scanning/28)

To fix the problem, you should add a `permissions` block to the workflow or the specific job to explicitly limit the permissions granted to the GITHUB_TOKEN. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not modify them. If the workflow requires additional permissions (e.g., to create releases or tags), you can add those specific permissions as needed. In this case, since the workflow runs semantic-release (which may need to create releases and tags), you may need to grant `contents: write` and `packages: write` if publishing to GitHub Packages, but the minimal fix is to add `contents: read` at the job level for the `release` job in `.github/workflows/release.yaml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
