### PR TITLE
Potential fix for code scanning alert no. 37: Code injection

### DIFF
--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -45,9 +45,9 @@ jobs:
             done < .policyignore
       - name: Copy Cluster Policies to the target directory
         run: |
-          mkdir -p ${{ env.KYVERNO_POLICIES_DIR }}
-          rm -rf ${{ env.KYVERNO_POLICIES_DIR }}/*
-          cp -r ${{ env.KYVERNO_POLICIES_TEMP_DIR }}/* ${{ env.KYVERNO_POLICIES_DIR }} || echo "No policies found to copy."
+          mkdir -p "$KYVERNO_POLICIES_DIR"
+          rm -rf "$KYVERNO_POLICIES_DIR"/*
+          cp -r "$KYVERNO_POLICIES_TEMP_DIR"/* "$KYVERNO_POLICIES_DIR" || echo "No policies found to copy."
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/reusable-workflows/security/code-scanning/37](https://github.com/devantler-tech/reusable-workflows/security/code-scanning/37)

To fix the code injection vulnerability, we should avoid using `${{ env.KYVERNO_POLICIES_DIR }}` directly in shell commands. Instead, we should set the value to an environment variable and reference it using native shell syntax (`$KYVERNO_POLICIES_DIR`). This prevents shell injection because the shell will treat the value as a single argument, regardless of its contents. Specifically, in the affected step (lines 47–50), replace all instances of `${{ env.KYVERNO_POLICIES_DIR }}` with `$KYVERNO_POLICIES_DIR`. No additional imports or definitions are needed, as the environment variable is already set in the job's `env` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
