### PR TITLE
Potential fix for code scanning alert no. 33: Code injection

### DIFF
--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Remove blacklisted policies
         run: |
           while IFS= read -r pattern; do
-          find ${{ env.KYVERNO_POLICIES_TEMP_DIR }} -path "${{ env.KYVERNO_POLICIES_TEMP_DIR }}/$pattern" -exec rm -rf {} +
+          find "$KYVERNO_POLICIES_TEMP_DIR" -path "$KYVERNO_POLICIES_TEMP_DIR/$pattern" -exec rm -rf {} +
             done < .policyignore
       - name: Copy Cluster Policies to the target directory
         run: |

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Remove blacklisted policies
         run: |
           while IFS= read -r pattern; do
-          find "$KYVERNO_POLICIES_TEMP_DIR" -path "$KYVERNO_POLICIES_TEMP_DIR"/"$pattern" -exec rm -rf {} +
+          find "$KYVERNO_POLICIES_TEMP_DIR" -path "$KYVERNO_POLICIES_TEMP_DIR/$pattern" -exec rm -rf {} +
             done < .policyignore
       - name: Copy Cluster Policies to the target directory
         run: |

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Remove blacklisted policies
         run: |
           while IFS= read -r pattern; do
-          find "$KYVERNO_POLICIES_TEMP_DIR" -path "$KYVERNO_POLICIES_TEMP_DIR/$pattern" -exec rm -rf {} +
+          find "$KYVERNO_POLICIES_TEMP_DIR" -path "$KYVERNO_POLICIES_TEMP_DIR"/"$pattern" -exec rm -rf {} +
             done < .policyignore
       - name: Copy Cluster Policies to the target directory
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/reusable-workflows/security/code-scanning/33](https://github.com/devantler-tech/reusable-workflows/security/code-scanning/33)

To fix the problem, replace all instances of `${{ env.KYVERNO_POLICIES_TEMP_DIR }}` in shell commands with the shell-native variable expansion `$KYVERNO_POLICIES_TEMP_DIR`. Specifically, in `.github/workflows/sync-cluster-policies.yaml`, update line 44 in the `run:` block under "Remove blacklisted policies" to use `$KYVERNO_POLICIES_TEMP_DIR` instead of `${{ env.KYVERNO_POLICIES_TEMP_DIR }}`. No additional imports or definitions are needed, as the environment variable is already set in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
