### PR TITLE
Potential fix for code scanning alert no. 31: Code injection

### DIFF
--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -35,8 +35,8 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
       - name: Download latest Cluster Policies
         run: |
-          git clone --filter=blob:none --sparse https://github.com/kyverno/policies ${{ env.KYVERNO_POLICIES_TEMP_DIR }}
-          cd ${{ env.KYVERNO_POLICIES_TEMP_DIR }}
+          git clone --filter=blob:none --sparse https://github.com/kyverno/policies $KYVERNO_POLICIES_TEMP_DIR
+          cd "$KYVERNO_POLICIES_TEMP_DIR"
           git sparse-checkout set --no-cone '*/' ':!.*'
       - name: Remove blacklisted policies
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/reusable-workflows/security/code-scanning/31](https://github.com/devantler-tech/reusable-workflows/security/code-scanning/31)

To fix the problem, we should avoid using `${{ ... }}` syntax inside shell commands in the `run:` block. Instead, we should reference the environment variable using the shell's native syntax (`$KYVERNO_POLICIES_TEMP_DIR`). This change should be made on line 39, replacing `cd ${{ env.KYVERNO_POLICIES_TEMP_DIR }}` with `cd "$KYVERNO_POLICIES_TEMP_DIR"`. No additional imports or definitions are needed, as the environment variable is already set in the `env:` block for the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
