### PR TITLE
ci: skip all GO checks in merge queue

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -33,7 +33,10 @@ jobs:
     name: 🔍 Detect Changes
     runs-on: ubuntu-latest
     # Ignore Required Workflow runs on the reusable-workflows repo itself
-    if: github.repository != 'devantler-tech/reusable-workflows'
+    # Skip merge queue — these checks already passed on the PR
+    if: >-
+      github.repository != 'devantler-tech/reusable-workflows'
+      && github.event_name != 'merge_group'
     permissions:
       contents: read
       pull-requests: read
@@ -244,11 +247,11 @@ jobs:
     name: 🔍 Dead Code Analysis
     runs-on: ubuntu-latest
     needs: [changes]
-    # Skip if no Go files changed or on reusable-workflows repo; only on PRs and merge queue
+    # Skip if no Go files changed or on reusable-workflows repo; only on PRs
     if: |
       github.repository != 'devantler-tech/reusable-workflows'
       && needs.changes.outputs.go == 'true'
-      && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+      && github.event_name == 'pull_request'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
All CI - Go jobs currently run in both `pull_request` and `merge_group` events. Since the PR already validates these checks, re-running them in the merge queue wastes CI minutes. Skipped jobs count as success for required checks, so they can safely be omitted.

The `changes` job now skips in merge queue, which cascades to all 7 downstream jobs via `needs: [changes]`. The `deadcode` job's condition is also simplified to remove the now-unreachable `merge_group` reference.

## Type of change

- [x] 🧹 Refactor