### PR TITLE
refactor: update action references to renamed devantler-tech/actions

### DIFF
--- a/.github/workflows/.sync-labels.yaml
+++ b/.github/workflows/.sync-labels.yaml
@@ -24,4 +24,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-labels-action@f1fcdf7dd14ab98198c2965e222a9481098bc430 # main
+        uses: devantler-tech/actions/sync-github-labels@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -32,8 +32,8 @@ jobs:
           persist-credentials: false
 
       - name: 🔀 Auto-merge
-        uses: devantler-tech/actions/auto-merge-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
+        uses: devantler-tech/actions/enable-auto-merge-on-pr@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
         with:
-          app_id: ${{ vars.APP_ID }}
-          app_private_key: ${{ secrets.app-private-key }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ vars.APP_ID }}
+          app-private-key: ${{ secrets.app-private-key }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -37,9 +37,9 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/dotnet-test-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
+        uses: devantler-tech/actions/run-dotnet-tests@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
         with:
-          app_id: ${{ vars.APP_ID }}
-          app_private_key: ${{ secrets.app-private-key }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ vars.APP_ID }}
+          app-private-key: ${{ secrets.app-private-key }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           codecov-token: ${{ secrets.codecov-token }}

--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -25,9 +25,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 🧪 Run todos-action
-        uses: devantler-tech/actions/todos-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
+      - name: 📝 Create issues from TODOs
+        uses: devantler-tech/actions/create-issues-from-todos@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
         with:
-          APP_ID: ${{ vars.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.app-private-key }}
-          PROJECT: organization/devantler-tech/5
+          app-id: ${{ vars.APP_ID }}
+          app-private-key: ${{ secrets.app-private-key }}
+          project: organization/devantler-tech/5


### PR DESCRIPTION
## Summary

Updates `uses:` action paths and input names in 4 workflows to match the renamed action directories and kebab-case inputs from [devantler-tech/actions PR #52](https://github.com/devantler-tech/actions/pull/52).

> [!NOTE]
> This PR stacks on top of #188. Merge #188 first.

> [!IMPORTANT]
> The SHA pins (`a7a2ace351e0d666607f4b8c4d59c875244bc21b`) point to the `devantler-tech/actions` PR #52 branch head. Update them to the release tag once that PR is merged.

## Changes

### Action directory renames

| Workflow | Old path | New path |
|----------|----------|----------|
| `enable-auto-merge.yaml` | `auto-merge-action` | `enable-auto-merge-on-pr` |
| `.sync-labels.yaml` | `sync-labels-action` | `sync-github-labels` |
| `run-dotnet-tests.yaml` | `dotnet-test-action` | `run-dotnet-tests` |
| `scan-for-todo-comments.yaml` | `todos-action` | `create-issues-from-todos` |

### Input renames to kebab-case

| Workflow | Old | New |
|----------|-----|-----|
| `enable-auto-merge.yaml` | `app_id`, `app_private_key`, `github_token` | `app-id`, `app-private-key`, `github-token` |
| `run-dotnet-tests.yaml` | `app_id`, `app_private_key`, `github_token` | `app-id`, `app-private-key`, `github-token` |
| `scan-for-todo-comments.yaml` | `APP_ID`, `APP_PRIVATE_KEY`, `PROJECT` | `app-id`, `app-private-key`, `project` |

### New actions available (future use)

The following new actions from `devantler-tech/actions` PR #52 are available but not yet used (no applicable place in current workflows):

- `login-to-ghcr` — Login to GHCR via `docker/login-action` (input: `token`)
- `setup-go-toolchain` — Setup Go with optional private module support (inputs: `go-version`, `token`; output: `go-version`)