### PR TITLE
ci: rename status jobs to `status-check` for unified required check

### DIFF
--- a/.github/workflows/test-delete-workflow-runs.yaml
+++ b/.github/workflows/test-delete-workflow-runs.yaml
@@ -51,7 +51,7 @@ jobs:
       contents: read
 
   test-delete-workflow-runs-status:
-    name: "[Test] Delete Workflow Runs - Status"
+    name: status-check
     runs-on: ubuntu-latest
     needs:
       [

--- a/.github/workflows/test-scan-for-workflow-vulnerabilities.yaml
+++ b/.github/workflows/test-scan-for-workflow-vulnerabilities.yaml
@@ -24,7 +24,7 @@ jobs:
       actions: read
 
   test-zizmor-status:
-    name: "[Test] Zizmor - Status"
+    name: status-check
     runs-on: ubuntu-latest
     needs: [test-zizmor]
     permissions: {}


### PR DESCRIPTION
## Summary

Renames the status aggregation job in every test workflow to `status-check`, so a single required status check can gate all test workflows in branch protection rules.

### Changes

- **`test-scan-for-workflow-vulnerabilities.yaml`** — `[Test] Zizmor - Status` → `status-check`
- **`test-delete-workflow-runs.yaml`** — `[Test] Delete Workflow Runs - Status` → `status-check`