### PR TITLE
feat: update enable-auto-merge to use split approve-pr and enable-auto-merge-on-pr actions

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -26,14 +26,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 📑 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: 🔀 Auto-merge
-        uses: devantler-tech/actions/enable-auto-merge-on-pr@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
+      - name: ✅ Approve PR
+        uses: devantler-tech/actions/approve-pr@ba492559ea1bd82fdb0755e3e936dfa6db83be8f # pending release
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+
+      - name: 🔀 Enable Auto-Merge
+        uses: devantler-tech/actions/enable-auto-merge-on-pr@ba492559ea1bd82fdb0755e3e936dfa6db83be8f # pending release
+        with:
+          pr-number: ${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ jobs:
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/enable-auto-merge.yaml](.github/workflows/enable-auto-merge.yaml) is a workflow that enables auto-merge on pull requests from trusted bots and maintainers.
+[.github/workflows/enable-auto-merge.yaml](.github/workflows/enable-auto-merge.yaml) is a workflow that approves and enables auto-merge on pull requests from trusted bots and maintainers.
 
 #### Usage
 


### PR DESCRIPTION
## Summary

Updates `.github/workflows/enable-auto-merge.yaml` to use the two newly split composite actions from `devantler-tech/actions` (see [devantler-tech/actions#58](https://github.com/devantler-tech/actions/pull/58)).

## Changes

### `.github/workflows/enable-auto-merge.yaml`
- Replaced the single `enable-auto-merge-on-pr` step with two sequential steps:- Removed the `
 `devantler-tech/actions/approve-pr@ generates a GitHub App token and approves the PRba492559...` 
 `devantler-tech/actions/enable-auto-merge-on-pr@ uses `github.token` from context to enable auto-mergeba492559...` 
- Removed the now-unused `github-token` input (the new `enable-auto-merge-on-pr` uses `github.token` from context directly)

### `README.md`
- Updated the workflow description to mention both approve and auto-merge steps