### PR TITLE
feat: normalize secret input keys to UPPER_SNAKE_CASE

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: devantler-tech/actions/approve-pr@ba492559ea1bd82fdb0755e3e936dfa6db83be8f # pending release
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: 🔀 Enable Auto-Merge

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -40,6 +40,6 @@ jobs:
         uses: devantler-tech/actions/run-dotnet-tests@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -29,5 +29,5 @@ jobs:
         uses: devantler-tech/actions/create-issues-from-todos@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
         with:
           app-id: ${{ vars.APP_ID }}
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -7,8 +7,17 @@ rules:
         devantler-tech/*: ref-pin
         "*": hash-pin
   secrets-outside-env:
-    config:
-      allow:
-        - APP_PRIVATE_KEY
-        - NUGET_API_KEY
-        - CODECOV_TOKEN
+    ignore:
+      # Reusable workflows cannot rely on environment secrets consistently.
+      - create-release.yaml:25
+      - enable-auto-merge.yaml:33
+      - lint-documentation.yaml:35
+      - publish-dotnet-library.yaml:40
+      - run-dotnet-tests.yaml:43
+      - run-dotnet-tests.yaml:45
+      - scan-for-todo-comments.yaml:32
+      - sync-cluster-policies.yaml:35
+      - validate-go-project.yaml:147
+      - validate-go-project.yaml:212
+      - validate-go-project.yaml:328
+      - validate-go-project.yaml:476


### PR DESCRIPTION
## Summary

Renames all secret input keys in reusable workflow `with:` blocks from `kebab-case` to `UPPER_SNAKE_CASE`, consistent with how secrets are referenced via `${{ secrets.SECRET_NAME }}`.

Depends on [devantler-tech/actions#normalize-secret-input-keys](https://github.com/devantler-tech/actions/pulls) — the corresponding action input renames.

## Changes

- `enable-auto-merge.yaml`: `app-private-key` → `APP_PRIVATE_KEY`
- `run-dotnet-tests.yaml`: `app-private-key` → `APP_PRIVATE_KEY`, `github-token` → `GITHUB_TOKEN`, `codecov-token` → `CODECOV_TOKEN`
- `scan-for-todo-comments.yaml`: `app-private-key` → `APP_PRIVATE_KEY`