### PR TITLE
chore: pin actions to v2.1.0 SHA

### DIFF
--- a/.github/workflows/.sync-labels.yaml
+++ b/.github/workflows/.sync-labels.yaml
@@ -24,4 +24,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-github-labels@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
+        uses: devantler-tech/actions/sync-github-labels@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -27,13 +27,13 @@ jobs:
           egress-policy: audit
 
       - name: ✅ Approve PR
-        uses: devantler-tech/actions/approve-pr@ba492559ea1bd82fdb0755e3e936dfa6db83be8f # pending release
+        uses: devantler-tech/actions/approve-pr@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: 🔀 Enable Auto-Merge
-        uses: devantler-tech/actions/enable-auto-merge-on-pr@ba492559ea1bd82fdb0755e3e936dfa6db83be8f # pending release
+        uses: devantler-tech/actions/enable-auto-merge-on-pr@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
         with:
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/run-dotnet-tests@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
+        uses: devantler-tech/actions/run-dotnet-tests@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: 📝 Create issues from TODOs
-        uses: devantler-tech/actions/create-issues-from-todos@a7a2ace351e0d666607f4b8c4d59c875244bc21b # pending release
+        uses: devantler-tech/actions/create-issues-from-todos@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Pin all `devantler-tech/actions` workflow callsites to the latest semver release SHA:
`4235593b654b467bb57c2d2f492b1461eab37cba` (`v2.1.0`).

Fixes N/A

## Type of change

EOF- [ ] - [ ] - [ ] - [ ] - [x] 