### PR TITLE
fix: update actions refs after input rename

### DIFF
--- a/.github/workflows/.sync-labels.yaml
+++ b/.github/workflows/.sync-labels.yaml
@@ -24,4 +24,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-github-labels@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/sync-github-labels@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1

--- a/.github/workflows/.sync-labels.yaml
+++ b/.github/workflows/.sync-labels.yaml
@@ -24,4 +24,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-github-labels@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/sync-github-labels@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -27,13 +27,13 @@ jobs:
           egress-policy: audit
 
       - name: ✅ Approve PR
-        uses: devantler-tech/actions/approve-pr@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/approve-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
         with:
           app-id: ${{ vars.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: 🔀 Enable Auto-Merge
-        uses: devantler-tech/actions/enable-auto-merge-on-pr@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/enable-auto-merge-on-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
         with:
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -27,13 +27,13 @@ jobs:
           egress-policy: audit
 
       - name: ✅ Approve PR
-        uses: devantler-tech/actions/approve-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/approve-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: 🔀 Enable Auto-Merge
-        uses: devantler-tech/actions/enable-auto-merge-on-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/enable-auto-merge-on-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
         with:
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/run-dotnet-tests@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/run-dotnet-tests@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -37,9 +37,9 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/run-dotnet-tests@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/run-dotnet-tests@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
         with:
           app-id: ${{ vars.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -26,8 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: 📝 Create issues from TODOs
-        uses: devantler-tech/actions/create-issues-from-todos@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/create-issues-from-todos@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
         with:
           app-id: ${{ vars.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           project: organization/devantler-tech/5

--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: 📝 Create issues from TODOs
-        uses: devantler-tech/actions/create-issues-from-todos@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/create-issues-from-todos@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Please include a summary of the changes. **What** has changed and **why**?.

Updates the direct `devantler-tech/actions/*` pins in `reusable-workflows` to the released v2.1.1 commit from https://github.com/devantler-tech/actions/pull/72. It also switches the affected action calls to the normalized kebab-case inputs so the reusable workflows stay aligned with the merged action interfaces.

The refs now point at the released v2.1.1 tag from the actions repo.

Fixes N/A

## Type of change

Select the appropriate options and delete the rest:

- [ ] 🧹 Refactor
- [x] 🪲 Bug fix
- [ ] 🚀 New feature
- [ ] ⛓️‍💥 Breaking change
- [ ] 📚 Documentation update
