### PR TITLE
fix: use v2.1.1 tag refs for internal actions

### DIFF
--- a/.github/workflows/.sync-labels.yaml
+++ b/.github/workflows/.sync-labels.yaml
@@ -24,4 +24,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-github-labels@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
+        uses: devantler-tech/actions/sync-github-labels@v2.1.1

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -27,13 +27,13 @@ jobs:
           egress-policy: audit
 
       - name: ✅ Approve PR
-        uses: devantler-tech/actions/approve-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
+        uses: devantler-tech/actions/approve-pr@v2.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: 🔀 Enable Auto-Merge
-        uses: devantler-tech/actions/enable-auto-merge-on-pr@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
+        uses: devantler-tech/actions/enable-auto-merge-on-pr@v2.1.1
         with:
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/run-dotnet-tests@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
+        uses: devantler-tech/actions/run-dotnet-tests@v2.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: 📝 Create issues from TODOs
-        uses: devantler-tech/actions/create-issues-from-todos@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
+        uses: devantler-tech/actions/create-issues-from-todos@v2.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Please include a summary of the changes. **What** has changed and **why**?.

Updated the specified reusable workflows to use released `devantler-tech/actions/...@v2.1.1` tag refs instead of the merged commit-SHA pins with trailing comments. This applies the intended follow-up correction while preserving the existing kebab-case action input names.

Fixes N/A

## Type of change

Select the appropriate options and delete the rest:

EOF- [ ] - [ ] - [ ] - [x] - [ ] 