### PR TITLE
fix: use go-version-file: go.mod instead of hardcoded go 1.26.1

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -155,7 +155,7 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.1
+          go-version-file: go.mod
 
       - name: 🧹 go mod tidy
         run: go mod tidy
@@ -220,7 +220,7 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.1
+          go-version-file: go.mod
 
       - name: 🧹 Run golangci-lint
         id: golangci-lint
@@ -281,7 +281,7 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.1
+          go-version-file: go.mod
           cache: true
 
       - name: 📥 Install deadcode
@@ -336,7 +336,7 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.1
+          go-version-file: go.mod
 
       - name: 🧹 Lint
         id: ml
@@ -399,7 +399,7 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.1
+          go-version-file: go.mod
           cache: true
 
       - name: 🛠️ Build
@@ -429,7 +429,7 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.1
+          go-version-file: go.mod
           cache: true
 
       - name: 🧪 Test
@@ -460,11 +460,11 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.1
+          go-version-file: go.mod
           cache: true
 
       - name: 👨🏻‍🔧 Enable covdata (temp) see https://github.com/golang/go/issues/75031
-        run: go env -w GOTOOLCHAIN=go1.25.0+auto
+        run: go env -w GOTOOLCHAIN=go1.26.0+auto
 
       - name: 📄 Generate coverage
         run: |


### PR DESCRIPTION
## Summary

Replace hardcoded `go-version: 1.26.1` with `go-version-file: go.mod` in all jobs of the `validate-go-project.yaml` workflow.

### Root Cause

The `validate-go-project.yaml` workflow hardcodes `go-version: 1.26.1`, which causes CI failures when a project's `go.mod` requires a higher Go version. For example, bumping `github.com/siderolabs/omni/client` from v1.6.4 to v1.6.5 requires Go 1.26.2, but the workflow installs Go 1.26.1 with `GOTOOLCHAIN=local`, causing all Go jobs to fail with:

```
go: go.mod requires go >= 1.26.2 (running go 1.26.1; GOTOOLCHAIN=local)
```

See: devantler-tech/ksail#4074

### Changes

- Replace `go-version: 1.26.1` → `go-version-file: go.mod` in all 7 jobs (`tidy`, `golangci-lint`, `deadcode`, `lint`, `build`, `test`, `coverage`)
- Update coverage job `GOTOOLCHAIN` from `go1.25.0+auto` to `go1.26.0+auto` to match the 1.26.x toolchain line

### Benefit

The workflow now automatically adapts to the Go version required by each project, so Dependabot bumps that advance the `go` directive in `go.mod` will no longer cause CI failures.