### PR TITLE
feat(update-copilot-skills): reusable workflow for gh skill updates

### DIFF
--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -43,11 +43,6 @@ on:
         required: false
         type: string
         default: "chore(deps): update copilot skills"
-      setup-action-ref:
-        description: Ref of `devantler-tech/actions/setup-copilot-skills` to use
-        required: false
-        type: string
-        default: main
 
 permissions: {}
 
@@ -70,7 +65,7 @@ jobs:
           persist-credentials: true
 
       - name: 📦 Install skills
-        uses: devantler-tech/actions/setup-copilot-skills@${{ inputs.setup-action-ref }}
+        uses: devantler-tech/actions/setup-copilot-skills@main # pin by SHA after initial release
         with:
           skills-lock: ${{ inputs.skills-lock }}
           agent: ${{ inputs.agent }}

--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: true
 
       - name: 📦 Install skills
-        uses: devantler-tech/actions/setup-copilot-skills@main # pin by SHA after initial release
+        uses: devantler-tech/actions/setup-copilot-skills@538d7103ed24531647941b3a460393b5ac7ed756 # v2.2.0
         with:
           skills-lock: ${{ inputs.skills-lock }}
           agent: ${{ inputs.agent }}

--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -1,0 +1,93 @@
+name: 🔄 Update Copilot Skills
+
+on:
+  workflow_call:
+    inputs:
+      skills-lock:
+        description: Path to the skills-lock.json manifest
+        required: false
+        type: string
+        default: skills-lock.json
+      agent:
+        description: Value passed to `gh skill install --agent`
+        required: false
+        type: string
+        default: github-copilot
+      scope:
+        description: Value passed to `gh skill install --scope` (`user` or `repo`)
+        required: false
+        type: string
+        default: user
+      gh-version:
+        description: Minimum required `gh` version (must support `gh skill`)
+        required: false
+        type: string
+        default: 2.90.0
+      pr-branch:
+        description: Branch the update PR is opened from
+        required: false
+        type: string
+        default: deps/copilot-skills-update
+      pr-title:
+        description: Title of the update PR
+        required: false
+        type: string
+        default: "chore(deps): update copilot skills"
+      pr-labels:
+        description: Comma-separated labels applied to the update PR
+        required: false
+        type: string
+        default: dependencies,automation
+      commit-message:
+        description: Commit message for the update PR
+        required: false
+        type: string
+        default: "chore(deps): update copilot skills"
+      setup-action-ref:
+        description: Ref of `devantler-tech/actions/setup-copilot-skills` to use
+        required: false
+        type: string
+        default: main
+
+permissions: {}
+
+jobs:
+  update-copilot-skills:
+    name: Update Copilot skills
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true
+
+      - name: 📦 Install skills
+        uses: devantler-tech/actions/setup-copilot-skills@${{ inputs.setup-action-ref }}
+        with:
+          skills-lock: ${{ inputs.skills-lock }}
+          agent: ${{ inputs.agent }}
+          scope: ${{ inputs.scope }}
+          gh-version: ${{ inputs.gh-version }}
+
+      - name: 📦 Create pull request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          commit-message: ${{ inputs.commit-message }}
+          title: ${{ inputs.pr-title }}
+          body: |
+            Automated update of Copilot skills to their latest versions.
+
+            Updated files:
+            - `${{ inputs.skills-lock }}`
+            - `.agents/skills/`
+          branch: ${{ inputs.pr-branch }}
+          labels: ${{ inputs.pr-labels }}
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -300,6 +300,58 @@ jobs:
 
 </details>
 
+### 🔄 Update Copilot Skills
+
+<details>
+<summary>Click to expand</summary>
+
+[.github/workflows/update-copilot-skills.yaml](.github/workflows/update-copilot-skills.yaml) is a workflow used to install and update Copilot / agent skills from a `skills-lock.json` manifest via [`gh skill`](https://github.com/cli/cli), opening a PR with any changes. It works with any `gh skill`-compatible skills repo (e.g. [`devantler-tech/skills`](https://github.com/devantler-tech/skills)).
+
+#### Usage
+
+```yaml
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-copilot-skills:
+    uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@{ref} # ref
+    permissions:
+      contents: write
+      pull-requests: write
+```
+
+A `skills-lock.json` at the repository root is expected by default:
+
+```json
+{
+  "version": 1,
+  "skills": {
+    "git-commit": { "source": "devantler-tech/skills", "sourceType": "github" }
+  }
+}
+```
+
+#### Secrets and Inputs
+
+| Key                 | Type           | Default                                | Required | Description                                                  |
+|---------------------|----------------|----------------------------------------|----------|--------------------------------------------------------------|
+| `skills-lock`       | Input (string) | `skills-lock.json`                     | No       | Path to the skills-lock.json manifest                        |
+| `agent`             | Input (string) | `github-copilot`                       | No       | Value passed to `gh skill install --agent`                   |
+| `scope`             | Input (string) | `user`                                 | No       | Value passed to `gh skill install --scope` (`user` or `repo`) |
+| `gh-version`        | Input (string) | `2.90.0`                               | No       | Minimum required `gh` version (must support `gh skill`)      |
+| `pr-branch`         | Input (string) | `deps/copilot-skills-update`           | No       | Branch the update PR is opened from                          |
+| `pr-title`          | Input (string) | `chore(deps): update copilot skills`   | No       | Title of the update PR                                       |
+| `pr-labels`         | Input (string) | `dependencies,automation`              | No       | Comma-separated labels for the update PR                     |
+| `commit-message`    | Input (string) | `chore(deps): update copilot skills`   | No       | Commit message for the update PR                             |
+| `setup-action-ref`  | Input (string) | `main`                                 | No       | Ref of `devantler-tech/actions/setup-copilot-skills` to use  |
+
+> **Note:** The calling workflow must grant `contents: write` and `pull-requests: write` permissions.
+
+</details>
+
 ### ✅ Validate Go Project
 
 <details>

--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ A `skills-lock.json` at the repository root is expected by default:
 | `pr-title`          | Input (string) | `chore(deps): update copilot skills`   | No       | Title of the update PR                                       |
 | `pr-labels`         | Input (string) | `dependencies,automation`              | No       | Comma-separated labels for the update PR                     |
 | `commit-message`    | Input (string) | `chore(deps): update copilot skills`   | No       | Commit message for the update PR                             |
-| `setup-action-ref`  | Input (string) | `main`                                 | No       | Ref of `devantler-tech/actions/setup-copilot-skills` to use  |
 
 > **Note:** The calling workflow must grant `contents: write` and `pull-requests: write` permissions.
 

--- a/README.md
+++ b/README.md
@@ -336,16 +336,16 @@ A `skills-lock.json` at the repository root is expected by default:
 
 #### Secrets and Inputs
 
-| Key                 | Type           | Default                                | Required | Description                                                  |
-|---------------------|----------------|----------------------------------------|----------|--------------------------------------------------------------|
-| `skills-lock`       | Input (string) | `skills-lock.json`                     | No       | Path to the skills-lock.json manifest                        |
-| `agent`             | Input (string) | `github-copilot`                       | No       | Value passed to `gh skill install --agent`                   |
-| `scope`             | Input (string) | `user`                                 | No       | Value passed to `gh skill install --scope` (`user` or `repo`) |
-| `gh-version`        | Input (string) | `2.90.0`                               | No       | Minimum required `gh` version (must support `gh skill`)      |
-| `pr-branch`         | Input (string) | `deps/copilot-skills-update`           | No       | Branch the update PR is opened from                          |
-| `pr-title`          | Input (string) | `chore(deps): update copilot skills`   | No       | Title of the update PR                                       |
-| `pr-labels`         | Input (string) | `dependencies,automation`              | No       | Comma-separated labels for the update PR                     |
-| `commit-message`    | Input (string) | `chore(deps): update copilot skills`   | No       | Commit message for the update PR                             |
+| Key              | Type           | Default                              | Required | Description                                                   |
+|------------------|----------------|--------------------------------------|----------|---------------------------------------------------------------|
+| `skills-lock`    | Input (string) | `skills-lock.json`                   | No       | Path to the skills-lock.json manifest                         |
+| `agent`          | Input (string) | `github-copilot`                     | No       | Value passed to `gh skill install --agent`                    |
+| `scope`          | Input (string) | `user`                               | No       | Value passed to `gh skill install --scope` (`user` or `repo`) |
+| `gh-version`     | Input (string) | `2.90.0`                             | No       | Minimum required `gh` version (must support `gh skill`)       |
+| `pr-branch`      | Input (string) | `deps/copilot-skills-update`         | No       | Branch the update PR is opened from                           |
+| `pr-title`       | Input (string) | `chore(deps): update copilot skills` | No       | Title of the update PR                                        |
+| `pr-labels`      | Input (string) | `dependencies,automation`            | No       | Comma-separated labels for the update PR                      |
+| `commit-message` | Input (string) | `chore(deps): update copilot skills` | No       | Commit message for the update PR                              |
 
 > **Note:** The calling workflow must grant `contents: write` and `pull-requests: write` permissions.
 


### PR DESCRIPTION
Add `update-copilot-skills.yaml`, a reusable workflow that installs and updates agent skills from a `skills-lock.json` manifest via [`gh skill`](https://github.com/cli/cli) and opens a PR with any changes.

## What has changed and why?

Mirrors the scheduled updater currently inlined in [devantler-tech/ksail#4105](https://github.com/devantler-tech/ksail/pull/4105), but makes it generic and reusable. Consumers can adopt the pattern with a single `uses:` line.

### Features

- Wraps [`devantler-tech/actions/setup-copilot-skills`](https://github.com/devantler-tech/actions/pull/74) so the install logic lives in one place.
- Works with any `gh skill`-compatible skills repo (e.g. [`devantler-tech/skills`](https://github.com/devantler-tech/skills)) — the source is read from each entry's `source` field in `skills-lock.json`.
- All PR metadata (branch, title, labels, commit message) is configurable via inputs.
- `setup-action-ref` input lets consumers pin the composite action to a specific ref.

## Related

- [devantler-tech/skills#1](https://github.com/devantler-tech/skills/pull/1)
- [devantler-tech/actions#74](https://github.com/devantler-tech/actions/pull/74)

## Type of change

- [x] 🚀 New feature
