### PR TITLE
fix(enable-auto-merge): gracefully handle self-authored PR approval

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -39,8 +39,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          gh pr review "$PR_NUMBER" --approve --repo "$REPOSITORY"
-          echo "✅ PR #${PR_NUMBER} approved"
+          if ! gh pr review "$PR_NUMBER" --approve --repo "$REPOSITORY" 2>&1; then
+            echo "::warning::Could not approve PR #${PR_NUMBER} (self-authored PRs cannot be self-approved). Skipping approval."
+          else
+            echo "✅ PR #${PR_NUMBER} approved"
+          fi
 
       - name: 🔀 Enable Auto-Merge
         env:

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -39,10 +39,19 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          if ! gh pr review "$PR_NUMBER" --approve --repo "$REPOSITORY" 2>&1; then
-            echo "::warning::Could not approve PR #${PR_NUMBER} (self-authored PRs cannot be self-approved). Skipping approval."
-          else
+          set +e
+          REVIEW_OUTPUT=$(gh pr review "$PR_NUMBER" --approve --repo "$REPOSITORY" 2>&1)
+          REVIEW_EXIT_CODE=$?
+          set -e
+
+          if [[ $REVIEW_EXIT_CODE -eq 0 ]]; then
             echo "✅ PR #${PR_NUMBER} approved"
+          elif [[ "$REVIEW_OUTPUT" == *"Can not approve your own pull request"* ]]; then
+            echo "::warning::Could not approve PR #${PR_NUMBER} because GitHub does not allow self-approval. Skipping approval."
+          else
+            echo "::error::Failed to approve PR #${PR_NUMBER}."
+            echo "$REVIEW_OUTPUT"
+            exit 1
           fi
 
       - name: 🔀 Enable Auto-Merge


### PR DESCRIPTION
## Summary

The `approve` step in `enable-auto-merge.yaml` uses the GitHub App token (configured via `vars.APP_ID`, which is `botantler[bot]`). When `botantler[bot]` creates a PR, the same App identity is used for approval — GitHub blocks this with _"Can not approve your own pull request"_, causing the required workflow to fail for all `botantler[bot]`-authored PRs.

## Root cause

Introduced in commit `4afd2c6` (_"fix: use GitHub App token for auto-merge to support workflow-changing PRs"_). The intent was to use the App token for the **merge** step (which requires `workflows` permission), but the **approval** step was inadvertently switched to the same App token, which breaks self-authored PRs.

## Fix

Treat the self-approval error as a non-fatal warning. Human reviewers still approve these PRs independently (and have done so for the currently blocked PR devantler-tech/monorepo#1536).

## Related

Unblocks devantler-tech/monorepo#1536.