### PR TITLE
fix(update-copilot-skills): default scope to repo

### DIFF
--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -17,7 +17,7 @@ on:
         description: Value passed to `gh skill install --scope` (`user` or `repo`)
         required: false
         type: string
-        default: user
+        default: repo
       gh-version:
         description: Minimum required `gh` version (must support `gh skill`)
         required: false


### PR DESCRIPTION
The reusable workflow defaulted `scope` to `user`, which makes `gh skill install` write to `~/.copilot/skills` on the runner — outside `GITHUB_WORKSPACE`. The working tree therefore never changes and the `peter-evans/create-pull-request` step opens no PR.

Concrete failure example: [`devantler-tech/ksail` run 24609491046](https://github.com/devantler-tech/ksail/actions/runs/24609491046) succeeded but produced no PR. The PR-creation step logs:

```
No local changes to save
Branch 'deps/copilot-skills-update' is not ahead of base 'main' and will not be created
```

Default to `repo` so installs land inside the checkout. Mirrors the matching default change in [`devantler-tech/actions#85`](https://github.com/devantler-tech/actions/pull/85). Once that PR ships a release, the `setup-copilot-skills` pin in this workflow will be bumped on this branch in a follow-up commit before merge.

## Type of change

- [x] 🪲 Bug fix
- [x] ⛓️‍💥 Breaking change (default behaviour changes for existing callers; opt back in with `scope: user`)