### PR TITLE
feat(update-copilot-skills): resolve and pin skill refs before install

### DIFF
--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -14,7 +14,7 @@ on:
         type: string
         default: github-copilot
       scope:
-        description: Value passed to `gh skill install --scope` (`user` or `repo`)
+        description: Value passed to `gh skill install --scope` (`project` or `user`)
         required: false
         type: string
         default: user
@@ -64,8 +64,14 @@ jobs:
         with:
           persist-credentials: true
 
+      - name: 🔄 Resolve and pin latest skill refs
+        uses: devantler-tech/actions/update-copilot-skills@bf04cc00fffcc37b573cdf045556f3f26fe9fe8c # main @ 2026-04-18
+        with:
+          skills-lock: ${{ inputs.skills-lock }}
+          gh-version: ${{ inputs.gh-version }}
+
       - name: 📦 Install skills
-        uses: devantler-tech/actions/setup-copilot-skills@538d7103ed24531647941b3a460393b5ac7ed756 # v2.2.0
+        uses: devantler-tech/actions/setup-copilot-skills@bf04cc00fffcc37b573cdf045556f3f26fe9fe8c # main @ 2026-04-18
         with:
           skills-lock: ${{ inputs.skills-lock }}
           agent: ${{ inputs.agent }}


### PR DESCRIPTION
Adds a new `update-copilot-skills` step to the scheduled `update-copilot-skills.yaml` reusable workflow so the daily/weekly run now rewrites `skills-lock.json` with the latest resolved ref/digest per source before `setup-copilot-skills` installs them. Without this step the workflow would only install whatever is already pinned, so the opened PRs never actually bumped the lockfile — exactly the gap that [devantler-tech/actions#87](https://github.com/devantler-tech/actions/issues/87) tracked.

## Changes

- **New step**: `devantler-tech/actions/update-copilot-skills` (resolve latest tag / default-branch HEAD → write `ref` + `digest` back to `skills-lock.json`).
- **Bump pin**: `setup-copilot-skills` ref moves from `v2.2.0` → main @ `bf04cc0` so it picks up the new `--pin` support that respects the digest/ref written above.
- **Docs fix**: `scope` input description now reads `project | user` (the actual values `gh skill install --scope` accepts).

## Context

- Companion to [devantler-tech/actions#88](https://github.com/devantler-tech/actions/pull/88) + [#92](https://github.com/devantler-tech/actions/pull/92).
- Both action refs will be re-pinned to a tagged release once the next release of `devantler-tech/actions` is cut (auto-merge commits don't trigger the release workflow).
