### PR TITLE
refactor(update-copilot-skills)!: drop skills-lock, use gh skill update --all

### DIFF
--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -3,21 +3,16 @@ name: 🔄 Update Copilot Skills
 on:
   workflow_call:
     inputs:
-      skills-lock:
-        description: Path to the skills-lock.json manifest
+      dir:
+        description: Directory to scan for installed skills (passed to `gh skill update --dir`)
         required: false
         type: string
-        default: skills-lock.json
-      agent:
-        description: Value passed to `gh skill install --agent`
+        default: "."
+      unpin:
+        description: When `true`, pass `--unpin` to `gh skill update` (clear pins and include pinned skills)
         required: false
-        type: string
-        default: github-copilot
-      scope:
-        description: Value passed to `gh skill install --scope` (`project` or `user`)
-        required: false
-        type: string
-        default: repo
+        type: boolean
+        default: false
       gh-version:
         description: Minimum required `gh` version (must support `gh skill`)
         required: false
@@ -64,21 +59,16 @@ jobs:
         with:
           persist-credentials: true
 
-      - name: 🔄 Resolve and pin latest skill refs
-        uses: devantler-tech/actions/update-copilot-skills@bf04cc00fffcc37b573cdf045556f3f26fe9fe8c # main @ 2026-04-18
+      - name: 🔄 Update installed skills
+        id: update
+        uses: devantler-tech/actions/update-copilot-skills@d7625bdcc0333002ae3916284239511cf30b4837 # main @ 2026-04-19
         with:
-          skills-lock: ${{ inputs.skills-lock }}
-          gh-version: ${{ inputs.gh-version }}
-
-      - name: 📦 Install skills
-        uses: devantler-tech/actions/setup-copilot-skills@bf04cc00fffcc37b573cdf045556f3f26fe9fe8c # main @ 2026-04-18
-        with:
-          skills-lock: ${{ inputs.skills-lock }}
-          agent: ${{ inputs.agent }}
-          scope: ${{ inputs.scope }}
+          dir: ${{ inputs.dir }}
+          unpin: ${{ inputs.unpin }}
           gh-version: ${{ inputs.gh-version }}
 
       - name: 📦 Create pull request
+        if: steps.update.outputs.changed == 'true'
         uses: step-security/create-pull-request@e604d57b37b404d8bb34d152fa905e45d003a895 # v8.1.0
         with:
           commit-message: ${{ inputs.commit-message }}
@@ -86,9 +76,11 @@ jobs:
           body: |
             Automated update of Copilot skills to their latest versions.
 
-            Updated files:
-            - `${{ inputs.skills-lock }}`
-            - `.agents/skills/`
+            Updated files under `${{ inputs.dir }}`:
+
+            ```
+            ${{ steps.update.outputs.updated-skills }}
+            ```
           branch: ${{ inputs.pr-branch }}
           labels: ${{ inputs.pr-labels }}
           delete-branch: true

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ jobs:
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/update-copilot-skills.yaml](.github/workflows/update-copilot-skills.yaml) is a workflow used to install and update Copilot / agent skills from a `skills-lock.json` manifest via [`gh skill`](https://github.com/cli/cli), opening a PR with any changes. It works with any `gh skill`-compatible skills repo (e.g. [`devantler-tech/skills`](https://github.com/devantler-tech/skills)).
+[.github/workflows/update-copilot-skills.yaml](.github/workflows/update-copilot-skills.yaml) is a workflow used to keep installed Copilot / agent skills up-to-date via [`gh skill update --all`](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/), opening a PR with any changes. Each installed `SKILL.md`'s `metadata.github-*` frontmatter is the source of truth — no lockfile is required. Works with any mix of `gh skill`-compatible upstreams.
 
 #### Usage
 
@@ -321,31 +321,23 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    with:
+      dir: .agents/skills
 ```
 
-A `skills-lock.json` at the repository root is expected by default:
-
-```json
-{
-  "version": 1,
-  "skills": {
-    "git-commit": { "source": "devantler-tech/skills", "sourceType": "github" }
-  }
-}
-```
+The workflow assumes skills were previously installed with [`devantler-tech/actions/setup-copilot-skills`](https://github.com/devantler-tech/actions/tree/main/setup-copilot-skills) (or `gh skill install` directly) — the committed `SKILL.md` files carry the upstream pointers.
 
 #### Secrets and Inputs
 
-| Key              | Type           | Default                              | Required | Description                                                   |
-|------------------|----------------|--------------------------------------|----------|---------------------------------------------------------------|
-| `skills-lock`    | Input (string) | `skills-lock.json`                   | No       | Path to the skills-lock.json manifest                         |
-| `agent`          | Input (string) | `github-copilot`                     | No       | Value passed to `gh skill install --agent`                    |
-| `scope`          | Input (string) | `user`                               | No       | Value passed to `gh skill install --scope` (`user` or `repo`) |
-| `gh-version`     | Input (string) | `2.90.0`                             | No       | Minimum required `gh` version (must support `gh skill`)       |
-| `pr-branch`      | Input (string) | `deps/copilot-skills-update`         | No       | Branch the update PR is opened from                           |
-| `pr-title`       | Input (string) | `chore(deps): update copilot skills` | No       | Title of the update PR                                        |
-| `pr-labels`      | Input (string) | `dependencies,automation`            | No       | Comma-separated labels for the update PR                      |
-| `commit-message` | Input (string) | `chore(deps): update copilot skills` | No       | Commit message for the update PR                              |
+| Key              | Type            | Default                              | Required | Description                                                            |
+|------------------|-----------------|--------------------------------------|----------|------------------------------------------------------------------------|
+| `dir`            | Input (string)  | `.`                                  | No       | Directory to scan for installed skills (passed to `gh skill update --dir`) |
+| `unpin`          | Input (boolean) | `false`                              | No       | When `true`, pass `--unpin` (clear pinned versions)                    |
+| `gh-version`     | Input (string)  | `2.90.0`                             | No       | Minimum required `gh` version (must support `gh skill`)                |
+| `pr-branch`      | Input (string)  | `deps/copilot-skills-update`         | No       | Branch the update PR is opened from                                    |
+| `pr-title`       | Input (string)  | `chore(deps): update copilot skills` | No       | Title of the update PR                                                 |
+| `pr-labels`      | Input (string)  | `dependencies,automation`            | No       | Comma-separated labels for the update PR                               |
+| `commit-message` | Input (string)  | `chore(deps): update copilot skills` | No       | Commit message for the update PR                                       |
 
 > **Note:** The calling workflow must grant `contents: write` and `pull-requests: write` permissions.
 


### PR DESCRIPTION
Wrap [`devantler-tech/actions/update-copilot-skills@v2`](https://github.com/devantler-tech/actions/pull/95) which delegates to [`gh skill update --all`](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/). Installed `SKILL.md` files' own `metadata.github-*` frontmatter is the source of truth — no `skills-lock.json` required.

## Type of change

- [x] 🧹 Refactor
- [x] ⛓️‍💥 Breaking change
- [x] 📚 Documentation update

## What changed

- Drop the `skills-lock`, `agent`, and `scope` inputs.
- Drop the separate `setup-copilot-skills` re-install step — `gh skill update` edits installed `SKILL.md` files in place.
- Add `dir` (default `.`) and `unpin` inputs; bump the pinned action SHA to the companion [`devantler-tech/actions#95`](https://github.com/devantler-tech/actions/pull/95) head.
- Only open a PR when the action reports `changed=true`; embed the `updated-skills` output in the PR body.
- Refresh the README section to match.

## Breaking change

The `skills-lock`, `agent`, and `scope` inputs are removed. Consumers should delete their `skills-lock.json`, install each skill via `gh skill install` (or `devantler-tech/actions/setup-copilot-skills@v2`), commit the resulting `SKILL.md` files, and pass `dir:` pointing at the directory those files live under. Companion migration PRs: [`devantler-tech/skills#16`](https://github.com/devantler-tech/skills/pull/16), [`devantler-tech/actions#95`](https://github.com/devantler-tech/actions/pull/95), and follow-up PRs in `devantler-tech/ksail` + `devantler-tech/platform`.