### PR TITLE
chore(deps): pin update-copilot-skills to 4489b81

### DIFF
--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: 🔄 Update installed skills
         id: update
-        uses: devantler-tech/actions/update-copilot-skills@d7625bdcc0333002ae3916284239511cf30b4837 # main @ 2026-04-19
+        uses: devantler-tech/actions/update-copilot-skills@4489b810277f6c3ebbbe4626eee66e92e1a556e4 # main @ 2026-04-20
         with:
           dir: ${{ inputs.dir }}
           unpin: ${{ inputs.unpin }}


### PR DESCRIPTION
Pin `update-copilot-skills` action to [4489b81](https://github.com/devantler-tech/actions/commit/4489b810277f6c3ebbbe4626eee66e92e1a556e4) which adds auto-discovery of skill root directories (devantler-tech/actions#103).