### PR TITLE
chore(deps): pin update-copilot-skills action to v3.1.1

### DIFF
--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: 🔄 Update installed skills
         id: update
-        uses: devantler-tech/actions/update-copilot-skills@4489b810277f6c3ebbbe4626eee66e92e1a556e4 # main @ 2026-04-20
+        uses: devantler-tech/actions/update-copilot-skills@a5339799d371b6952e7d3abdc9ea1ca096a28dfe # v3.1.1
         with:
           dir: ${{ inputs.dir }}
           unpin: ${{ inputs.unpin }}


### PR DESCRIPTION
Pins the `update-copilot-skills` action to a tagged release SHA instead of tracking `main`.

## Changes

- `.github/workflows/update-copilot-skills.yaml`: Updated SHA from `4489b810277f6c3ebbbe4626eee66e92e1a556e4` (`main @ 2026-04-20`) to `a5339799d371b6952e7d3abdc9ea1ca096a28dfe` (`v3.1.1`)