### PR TITLE
fix: add ready_for_review to auto-merge pull_request trigger types

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -8,6 +8,7 @@ on:
         description: "The private key for the GitHub App"
   ### Required Workflow Triggers ###
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   ##################################
 


### PR DESCRIPTION
## Problem

The `🔀 Enable Auto-Merge` workflow was unexpectedly skipped on [ksail#4229](https://github.com/devantler-tech/ksail/pull/4229).

### Root Cause

The Copilot SWE agent created the PR as a **draft**. The workflow triggered on the `opened` event, but the job's `if` condition checked `!github.event.pull_request.draft` — which evaluated to `!true` → `false`, so the job was skipped.

When the PR was later converted to ready-for-review, the `ready_for_review` event fired, but the workflow didn't re-run because the bare `pull_request:` trigger defaults to `[opened, synchronize, reopened]` — it does **not** include `ready_for_review`.

Confirmed via [workflow run logs](https://github.com/devantler-tech/ksail/actions/runs/24694141135):

```
Evaluating: (!github.event.pull_request.draft && ...)
Expanded:   (!true && ...)
Result:     false
```

## Fix

Add explicit `types: [opened, synchronize, reopened, ready_for_review]` to the `pull_request` trigger so the workflow re-runs when a draft PR transitions to ready-for-review.

Fixes devantler-tech/ksail#4229