### PR TITLE
fix: add ksail-bot[bot] to auto-merge + install Copilot skills

### DIFF
--- a/.agents/skills/find-skills/SKILL.md
+++ b/.agents/skills/find-skills/SKILL.md
@@ -1,0 +1,146 @@
+---
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+metadata:
+    github-path: skills/find-skills
+    github-ref: refs/tags/v1.5.1
+    github-repo: https://github.com/vercel-labs/skills
+    github-tree-sha: 3013fdeb8a11b10b1eb795ec3ae8bfca38f7c26d
+name: find-skills
+---
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/.agents/skills/gh-cli/SKILL.md
+++ b/.agents/skills/gh-cli/SKILL.md
@@ -1,0 +1,2191 @@
+---
+description: GitHub CLI (gh) comprehensive reference for repositories, issues, pull requests, Actions, projects, releases, gists, codespaces, organizations, extensions, and all GitHub operations from the command line.
+metadata:
+    github-path: skills/gh-cli
+    github-ref: refs/heads/main
+    github-repo: https://github.com/github/awesome-copilot
+    github-tree-sha: 437437f7f20bcdbbdb3081cf164435a388c0a39a
+name: gh-cli
+---
+# GitHub CLI (gh)
+
+Comprehensive reference for GitHub CLI (gh) - work seamlessly with GitHub from the command line.
+
+**Version:** 2.85.0 (current as of January 2026)
+
+## Prerequisites
+
+### Installation
+
+```bash
+# macOS
+brew install gh
+
+# Linux
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install gh
+
+# Windows
+winget install --id GitHub.cli
+
+# Verify installation
+gh --version
+```
+
+### Authentication
+
+```bash
+# Interactive login (default: github.com)
+gh auth login
+
+# Login with specific hostname
+gh auth login --hostname enterprise.internal
+
+# Login with token
+gh auth login --with-token < mytoken.txt
+
+# Check authentication status
+gh auth status
+
+# Switch accounts
+gh auth switch --hostname github.com --user username
+
+# Logout
+gh auth logout --hostname github.com --user username
+```
+
+### Setup Git Integration
+
+```bash
+# Configure git to use gh as credential helper
+gh auth setup-git
+
+# View active token
+gh auth token
+
+# Refresh authentication scopes
+gh auth refresh --scopes write:org,read:public_key
+```
+
+## CLI Structure
+
+```
+gh                          # Root command
+├── auth                    # Authentication
+│   ├── login
+│   ├── logout
+│   ├── refresh
+│   ├── setup-git
+│   ├── status
+│   ├── switch
+│   └── token
+├── browse                  # Open in browser
+├── codespace               # GitHub Codespaces
+│   ├── code
+│   ├── cp
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   ├── jupyter
+│   ├── list
+│   ├── logs
+│   ├── ports
+│   ├── rebuild
+│   ├── ssh
+│   ├── stop
+│   └── view
+├── gist                    # Gists
+│   ├── clone
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   ├── list
+│   ├── rename
+│   └── view
+├── issue                   # Issues
+│   ├── create
+│   ├── list
+│   ├── status
+│   ├── close
+│   ├── comment
+│   ├── delete
+│   ├── develop
+│   ├── edit
+│   ├── lock
+│   ├── pin
+│   ├── reopen
+│   ├── transfer
+│   ├── unlock
+│   └── view
+├── org                     # Organizations
+│   └── list
+├── pr                      # Pull Requests
+│   ├── create
+│   ├── list
+│   ├── status
+│   ├── checkout
+│   ├── checks
+│   ├── close
+│   ├── comment
+│   ├── diff
+│   ├── edit
+│   ├── lock
+│   ├── merge
+│   ├── ready
+│   ├── reopen
+│   ├── revert
+│   ├── review
+│   ├── unlock
+│   ├── update-branch
+│   └── view
+├── project                 # Projects
+│   ├── close
+│   ├── copy
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   ├── field-create
+│   ├── field-delete
+│   ├── field-list
+│   ├── item-add
+│   ├── item-archive
+│   ├── item-create
+│   ├── item-delete
+│   ├── item-edit
+│   ├── item-list
+│   ├── link
+│   ├── list
+│   ├── mark-template
+│   ├── unlink
+│   └── view
+├── release                 # Releases
+│   ├── create
+│   ├── list
+│   ├── delete
+│   ├── delete-asset
+│   ├── download
+│   ├── edit
+│   ├── upload
+│   ├── verify
+│   ├── verify-asset
+│   └── view
+├── repo                    # Repositories
+│   ├── create
+│   ├── list
+│   ├── archive
+│   ├── autolink
+│   ├── clone
+│   ├── delete
+│   ├── deploy-key
+│   ├── edit
+│   ├── fork
+│   ├── gitignore
+│   ├── license
+│   ├── rename
+│   ├── set-default
+│   ├── sync
+│   ├── unarchive
+│   └── view
+├── cache                   # Actions caches
+│   ├── delete
+│   └── list
+├── run                     # Workflow runs
+│   ├── cancel
+│   ├── delete
+│   ├── download
+│   ├── list
+│   ├── rerun
+│   ├── view
+│   └── watch
+├── workflow                # Workflows
+│   ├── disable
+│   ├── enable
+│   ├── list
+│   ├── run
+│   └── view
+├── agent-task              # Agent tasks
+├── alias                   # Command aliases
+│   ├── delete
+│   ├── import
+│   ├── list
+│   └── set
+├── api                     # API requests
+├── attestation             # Artifact attestations
+│   ├── download
+│   ├── trusted-root
+│   └── verify
+├── completion              # Shell completion
+├── config                  # Configuration
+│   ├── clear-cache
+│   ├── get
+│   ├── list
+│   └── set
+├── extension               # Extensions
+│   ├── browse
+│   ├── create
+│   ├── exec
+│   ├── install
+│   ├── list
+│   ├── remove
+│   ├── search
+│   └── upgrade
+├── gpg-key                 # GPG keys
+│   ├── add
+│   ├── delete
+│   └── list
+├── label                   # Labels
+│   ├── clone
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   └── list
+├── preview                 # Preview features
+├── ruleset                 # Rulesets
+│   ├── check
+│   ├── list
+│   └── view
+├── search                  # Search
+│   ├── code
+│   ├── commits
+│   ├── issues
+│   ├── prs
+│   └── repos
+├── secret                  # Secrets
+│   ├── delete
+│   ├── list
+│   └── set
+├── ssh-key                 # SSH keys
+│   ├── add
+│   ├── delete
+│   └── list
+├── status                  # Status overview
+└── variable                # Variables
+    ├── delete
+    ├── get
+    ├── list
+    └── set
+```
+
+## Configuration
+
+### Global Configuration
+
+```bash
+# List all configuration
+gh config list
+
+# Get specific configuration value
+gh config list git_protocol
+gh config get editor
+
+# Set configuration value
+gh config set editor vim
+gh config set git_protocol ssh
+gh config set prompt disabled
+gh config set pager "less -R"
+
+# Clear configuration cache
+gh config clear-cache
+```
+
+### Environment Variables
+
+```bash
+# GitHub token (for automation)
+export GH_TOKEN=ghp_xxxxxxxxxxxx
+
+# GitHub hostname
+export GH_HOST=github.com
+
+# Disable prompts
+export GH_PROMPT_DISABLED=true
+
+# Custom editor
+export GH_EDITOR=vim
+
+# Custom pager
+export GH_PAGER=less
+
+# HTTP timeout
+export GH_TIMEOUT=30
+
+# Custom repository (override default)
+export GH_REPO=owner/repo
+
+# Custom git protocol
+export GH_ENTERPRISE_HOSTNAME=hostname
+```
+
+## Authentication (gh auth)
+
+### Login
+
+```bash
+# Interactive login
+gh auth login
+
+# Web-based authentication
+gh auth login --web
+
+# With clipboard for OAuth code
+gh auth login --web --clipboard
+
+# With specific git protocol
+gh auth login --git-protocol ssh
+
+# With custom hostname (GitHub Enterprise)
+gh auth login --hostname enterprise.internal
+
+# Login with token from stdin
+gh auth login --with-token < token.txt
+
+# Insecure storage (plain text)
+gh auth login --insecure-storage
+```
+
+### Status
+
+```bash
+# Show all authentication status
+gh auth status
+
+# Show active account only
+gh auth status --active
+
+# Show specific hostname
+gh auth status --hostname github.com
+
+# Show token in output
+gh auth status --show-token
+
+# JSON output
+gh auth status --json hosts
+
+# Filter with jq
+gh auth status --json hosts --jq '.hosts | add'
+```
+
+### Switch Accounts
+
+```bash
+# Interactive switch
+gh auth switch
+
+# Switch to specific user/host
+gh auth switch --hostname github.com --user monalisa
+```
+
+### Token
+
+```bash
+# Print authentication token
+gh auth token
+
+# Token for specific host/user
+gh auth token --hostname github.com --user monalisa
+```
+
+### Refresh
+
+```bash
+# Refresh credentials
+gh auth refresh
+
+# Add scopes
+gh auth refresh --scopes write:org,read:public_key
+
+# Remove scopes
+gh auth refresh --remove-scopes delete_repo
+
+# Reset to default scopes
+gh auth refresh --reset-scopes
+
+# With clipboard
+gh auth refresh --clipboard
+```
+
+### Setup Git
+
+```bash
+# Setup git credential helper
+gh auth setup-git
+
+# Setup for specific host
+gh auth setup-git --hostname enterprise.internal
+
+# Force setup even if host not known
+gh auth setup-git --hostname enterprise.internal --force
+```
+
+## Browse (gh browse)
+
+```bash
+# Open repository in browser
+gh browse
+
+# Open specific path
+gh browse script/
+gh browse main.go:312
+
+# Open issue or PR
+gh browse 123
+
+# Open commit
+gh browse 77507cd94ccafcf568f8560cfecde965fcfa63
+
+# Open with specific branch
+gh browse main.go --branch bug-fix
+
+# Open different repository
+gh browse --repo owner/repo
+
+# Open specific pages
+gh browse --actions       # Actions tab
+gh browse --projects      # Projects tab
+gh browse --releases      # Releases tab
+gh browse --settings      # Settings page
+gh browse --wiki          # Wiki page
+
+# Print URL instead of opening
+gh browse --no-browser
+```
+
+## Repositories (gh repo)
+
+### Create Repository
+
+```bash
+# Create new repository
+gh repo create my-repo
+
+# Create with description
+gh repo create my-repo --description "My awesome project"
+
+# Create public repository
+gh repo create my-repo --public
+
+# Create private repository
+gh repo create my-repo --private
+
+# Create with homepage
+gh repo create my-repo --homepage https://example.com
+
+# Create with license
+gh repo create my-repo --license mit
+
+# Create with gitignore
+gh repo create my-repo --gitignore python
+
+# Initialize as template repository
+gh repo create my-repo --template
+
+# Create repository in organization
+gh repo create org/my-repo
+
+# Create without cloning locally
+gh repo create my-repo --source=.
+
+# Disable issues
+gh repo create my-repo --disable-issues
+
+# Disable wiki
+gh repo create my-repo --disable-wiki
+```
+
+### Clone Repository
+
+```bash
+# Clone repository
+gh repo clone owner/repo
+
+# Clone to specific directory
+gh repo clone owner/repo my-directory
+
+# Clone with different branch
+gh repo clone owner/repo --branch develop
+```
+
+### List Repositories
+
+```bash
+# List all repositories
+gh repo list
+
+# List repositories for owner
+gh repo list owner
+
+# Limit results
+gh repo list --limit 50
+
+# Public repositories only
+gh repo list --public
+
+# Source repositories only (not forks)
+gh repo list --source
+
+# JSON output
+gh repo list --json name,visibility,owner
+
+# Table output
+gh repo list --limit 100 | tail -n +2
+
+# Filter with jq
+gh repo list --json name --jq '.[].name'
+```
+
+### View Repository
+
+```bash
+# View repository details
+gh repo view
+
+# View specific repository
+gh repo view owner/repo
+
+# JSON output
+gh repo view --json name,description,defaultBranchRef
+
+# View in browser
+gh repo view --web
+```
+
+### Edit Repository
+
+```bash
+# Edit description
+gh repo edit --description "New description"
+
+# Set homepage
+gh repo edit --homepage https://example.com
+
+# Change visibility
+gh repo edit --visibility private
+gh repo edit --visibility public
+
+# Enable/disable features
+gh repo edit --enable-issues
+gh repo edit --disable-issues
+gh repo edit --enable-wiki
+gh repo edit --disable-wiki
+gh repo edit --enable-projects
+gh repo edit --disable-projects
+
+# Set default branch
+gh repo edit --default-branch main
+
+# Rename repository
+gh repo rename new-name
+
+# Archive repository
+gh repo archive
+gh repo unarchive
+```
+
+### Delete Repository
+
+```bash
+# Delete repository
+gh repo delete owner/repo
+
+# Confirm without prompt
+gh repo delete owner/repo --yes
+```
+
+### Fork Repository
+
+```bash
+# Fork repository
+gh repo fork owner/repo
+
+# Fork to organization
+gh repo fork owner/repo --org org-name
+
+# Clone after forking
+gh repo fork owner/repo --clone
+
+# Remote name for fork
+gh repo fork owner/repo --remote-name upstream
+```
+
+### Sync Fork
+
+```bash
+# Sync fork with upstream
+gh repo sync
+
+# Sync specific branch
+gh repo sync --branch feature
+
+# Force sync
+gh repo sync --force
+```
+
+### Set Default Repository
+
+```bash
+# Set default repository for current directory
+gh repo set-default
+
+# Set default explicitly
+gh repo set-default owner/repo
+
+# Unset default
+gh repo set-default --unset
+```
+
+### Repository Autolinks
+
+```bash
+# List autolinks
+gh repo autolink list
+
+# Add autolink
+gh repo autolink add \
+  --key-prefix JIRA- \
+  --url-template https://jira.example.com/browse/<num>
+
+# Delete autolink
+gh repo autolink delete 12345
+```
+
+### Repository Deploy Keys
+
+```bash
+# List deploy keys
+gh repo deploy-key list
+
+# Add deploy key
+gh repo deploy-key add ~/.ssh/id_rsa.pub \
+  --title "Production server" \
+  --read-only
+
+# Delete deploy key
+gh repo deploy-key delete 12345
+```
+
+### Gitignore and License
+
+```bash
+# View gitignore template
+gh repo gitignore
+
+# View license template
+gh repo license mit
+
+# License with full name
+gh repo license mit --fullname "John Doe"
+```
+
+## Issues (gh issue)
+
+### Create Issue
+
+```bash
+# Create issue interactively
+gh issue create
+
+# Create with title
+gh issue create --title "Bug: Login not working"
+
+# Create with title and body
+gh issue create \
+  --title "Bug: Login not working" \
+  --body "Steps to reproduce..."
+
+# Create with body from file
+gh issue create --body-file issue.md
+
+# Create with labels
+gh issue create --title "Fix bug" --labels bug,high-priority
+
+# Create with assignees
+gh issue create --title "Fix bug" --assignee user1,user2
+
+# Create in specific repository
+gh issue create --repo owner/repo --title "Issue title"
+
+# Create issue from web
+gh issue create --web
+```
+
+### List Issues
+
+```bash
+# List all open issues
+gh issue list
+
+# List all issues (including closed)
+gh issue list --state all
+
+# List closed issues
+gh issue list --state closed
+
+# Limit results
+gh issue list --limit 50
+
+# Filter by assignee
+gh issue list --assignee username
+gh issue list --assignee @me
+
+# Filter by labels
+gh issue list --labels bug,enhancement
+
+# Filter by milestone
+gh issue list --milestone "v1.0"
+
+# Search/filter
+gh issue list --search "is:open is:issue label:bug"
+
+# JSON output
+gh issue list --json number,title,state,author
+
+# Table view
+gh issue list --json number,title,labels --jq '.[] | [.number, .title, .labels[].name] | @tsv'
+
+# Show comments count
+gh issue list --json number,title,comments --jq '.[] | [.number, .title, .comments]'
+
+# Sort by
+gh issue list --sort created --order desc
+```
+
+### View Issue
+
+```bash
+# View issue
+gh issue view 123
+
+# View with comments
+gh issue view 123 --comments
+
+# View in browser
+gh issue view 123 --web
+
+# JSON output
+gh issue view 123 --json title,body,state,labels,comments
+
+# View specific fields
+gh issue view 123 --json title --jq '.title'
+```
+
+### Edit Issue
+
+```bash
+# Edit interactively
+gh issue edit 123
+
+# Edit title
+gh issue edit 123 --title "New title"
+
+# Edit body
+gh issue edit 123 --body "New description"
+
+# Add labels
+gh issue edit 123 --add-label bug,high-priority
+
+# Remove labels
+gh issue edit 123 --remove-label stale
+
+# Add assignees
+gh issue edit 123 --add-assignee user1,user2
+
+# Remove assignees
+gh issue edit 123 --remove-assignee user1
+
+# Set milestone
+gh issue edit 123 --milestone "v1.0"
+```
+
+### Close/Reopen Issue
+
+```bash
+# Close issue
+gh issue close 123
+
+# Close with comment
+gh issue close 123 --comment "Fixed in PR #456"
+
+# Reopen issue
+gh issue reopen 123
+```
+
+### Comment on Issue
+
+```bash
+# Add comment
+gh issue comment 123 --body "This looks good!"
+
+# Edit comment
+gh issue comment 123 --edit 456789 --body "Updated comment"
+
+# Delete comment
+gh issue comment 123 --delete 456789
+```
+
+### Issue Status
+
+```bash
+# Show issue status summary
+gh issue status
+
+# Status for specific repository
+gh issue status --repo owner/repo
+```
+
+### Pin/Unpin Issues
+
+```bash
+# Pin issue (pinned to repo dashboard)
+gh issue pin 123
+
+# Unpin issue
+gh issue unpin 123
+```
+
+### Lock/Unlock Issue
+
+```bash
+# Lock conversation
+gh issue lock 123
+
+# Lock with reason
+gh issue lock 123 --reason off-topic
+
+# Unlock
+gh issue unlock 123
+```
+
+### Transfer Issue
+
+```bash
+# Transfer to another repository
+gh issue transfer 123 --repo owner/new-repo
+```
+
+### Delete Issue
+
+```bash
+# Delete issue
+gh issue delete 123
+
+# Confirm without prompt
+gh issue delete 123 --yes
+```
+
+### Develop Issue (Draft PR)
+
+```bash
+# Create draft PR from issue
+gh issue develop 123
+
+# Create in specific branch
+gh issue develop 123 --branch fix/issue-123
+
+# Create with base branch
+gh issue develop 123 --base main
+```
+
+## Pull Requests (gh pr)
+
+### Create Pull Request
+
+```bash
+# Create PR interactively
+gh pr create
+
+# Create with title
+gh pr create --title "Feature: Add new functionality"
+
+# Create with title and body
+gh pr create \
+  --title "Feature: Add new functionality" \
+  --body "This PR adds..."
+
+# Fill body from template
+gh pr create --body-file .github/PULL_REQUEST_TEMPLATE.md
+
+# Set base branch
+gh pr create --base main
+
+# Set head branch (default: current branch)
+gh pr create --head feature-branch
+
+# Create draft PR
+gh pr create --draft
+
+# Add assignees
+gh pr create --assignee user1,user2
+
+# Add reviewers
+gh pr create --reviewer user1,user2
+
+# Add labels
+gh pr create --labels enhancement,feature
+
+# Link to issue
+gh pr create --issue 123
+
+# Create in specific repository
+gh pr create --repo owner/repo
+
+# Open in browser after creation
+gh pr create --web
+```
+
+### List Pull Requests
+
+```bash
+# List open PRs
+gh pr list
+
+# List all PRs
+gh pr list --state all
+
+# List merged PRs
+gh pr list --state merged
+
+# List closed (not merged) PRs
+gh pr list --state closed
+
+# Filter by head branch
+gh pr list --head feature-branch
+
+# Filter by base branch
+gh pr list --base main
+
+# Filter by author
+gh pr list --author username
+gh pr list --author @me
+
+# Filter by assignee
+gh pr list --assignee username
+
+# Filter by labels
+gh pr list --labels bug,enhancement
+
+# Limit results
+gh pr list --limit 50
+
+# Search
+gh pr list --search "is:open is:pr label:review-required"
+
+# JSON output
+gh pr list --json number,title,state,author,headRefName
+
+# Show check status
+gh pr list --json number,title,statusCheckRollup --jq '.[] | [.number, .title, .statusCheckRollup[]?.status]'
+
+# Sort by
+gh pr list --sort created --order desc
+```
+
+### View Pull Request
+
+```bash
+# View PR
+gh pr view 123
+
+# View with comments
+gh pr view 123 --comments
+
+# View in browser
+gh pr view 123 --web
+
+# JSON output
+gh pr view 123 --json title,body,state,author,commits,files
+
+# View diff
+gh pr view 123 --json files --jq '.files[].path'
+
+# View with jq query
+gh pr view 123 --json title,state --jq '"\(.title): \(.state)"'
+```
+
+### Checkout Pull Request
+
+```bash
+# Checkout PR branch
+gh pr checkout 123
+
+# Checkout with specific branch name
+gh pr checkout 123 --branch name-123
+
+# Force checkout
+gh pr checkout 123 --force
+```
+
+### Diff Pull Request
+
+```bash
+# View PR diff
+gh pr diff 123
+
+# View diff with color
+gh pr diff 123 --color always
+
+# Output to file
+gh pr diff 123 > pr-123.patch
+
+# View diff of specific files
+gh pr diff 123 --name-only
+```
+
+### Merge Pull Request
+
+```bash
+# Merge PR
+gh pr merge 123
+
+# Merge with specific method
+gh pr merge 123 --merge
+gh pr merge 123 --squash
+gh pr merge 123 --rebase
+
+# Delete branch after merge
+gh pr merge 123 --delete-branch
+
+# Merge with comment
+gh pr merge 123 --subject "Merge PR #123" --body "Merging feature"
+
+# Merge draft PR
+gh pr merge 123 --admin
+
+# Force merge (skip checks)
+gh pr merge 123 --admin
+```
+
+### Close Pull Request
+
+```bash
+# Close PR (as draft, not merge)
+gh pr close 123
+
+# Close with comment
+gh pr close 123 --comment "Closing due to..."
+```
+
+### Reopen Pull Request
+
+```bash
+# Reopen closed PR
+gh pr reopen 123
+```
+
+### Edit Pull Request
+
+```bash
+# Edit interactively
+gh pr edit 123
+
+# Edit title
+gh pr edit 123 --title "New title"
+
+# Edit body
+gh pr edit 123 --body "New description"
+
+# Add labels
+gh pr edit 123 --add-label bug,enhancement
+
+# Remove labels
+gh pr edit 123 --remove-label stale
+
+# Add assignees
+gh pr edit 123 --add-assignee user1,user2
+
+# Remove assignees
+gh pr edit 123 --remove-assignee user1
+
+# Add reviewers
+gh pr edit 123 --add-reviewer user1,user2
+
+# Remove reviewers
+gh pr edit 123 --remove-reviewer user1
+
+# Mark as ready for review
+gh pr edit 123 --ready
+```
+
+### Ready for Review
+
+```bash
+# Mark draft PR as ready
+gh pr ready 123
+```
+
+### Pull Request Checks
+
+```bash
+# View PR checks
+gh pr checks 123
+
+# Watch checks in real-time
+gh pr checks 123 --watch
+
+# Watch interval (seconds)
+gh pr checks 123 --watch --interval 5
+```
+
+### Comment on Pull Request
+
+```bash
+# Add comment
+gh pr comment 123 --body "Looks good!"
+
+# Comment on specific line
+gh pr comment 123 --body "Fix this" \
+  --repo owner/repo \
+  --head-owner owner --head-branch feature
+
+# Edit comment
+gh pr comment 123 --edit 456789 --body "Updated"
+
+# Delete comment
+gh pr comment 123 --delete 456789
+```
+
+### Review Pull Request
+
+```bash
+# Review PR (opens editor)
+gh pr review 123
+
+# Approve PR
+gh pr review 123 --approve --body "LGTM!"
+
+# Request changes
+gh pr review 123 --request-changes \
+  --body "Please fix these issues"
+
+# Comment on PR
+gh pr review 123 --comment --body "Some thoughts..."
+
+# Dismiss review
+gh pr review 123 --dismiss
+```
+
+### Update Branch
+
+```bash
+# Update PR branch with latest base branch
+gh pr update-branch 123
+
+# Force update
+gh pr update-branch 123 --force
+
+# Use merge strategy
+gh pr update-branch 123 --merge
+```
+
+### Lock/Unlock Pull Request
+
+```bash
+# Lock PR conversation
+gh pr lock 123
+
+# Lock with reason
+gh pr lock 123 --reason off-topic
+
+# Unlock
+gh pr unlock 123
+```
+
+### Revert Pull Request
+
+```bash
+# Revert merged PR
+gh pr revert 123
+
+# Revert with specific branch name
+gh pr revert 123 --branch revert-pr-123
+```
+
+### Pull Request Status
+
+```bash
+# Show PR status summary
+gh pr status
+
+# Status for specific repository
+gh pr status --repo owner/repo
+```
+
+## GitHub Actions
+
+### Workflow Runs (gh run)
+
+```bash
+# List workflow runs
+gh run list
+
+# List for specific workflow
+gh run list --workflow "ci.yml"
+
+# List for specific branch
+gh run list --branch main
+
+# Limit results
+gh run list --limit 20
+
+# JSON output
+gh run list --json databaseId,status,conclusion,headBranch
+
+# View run details
+gh run view 123456789
+
+# View run with verbose logs
+gh run view 123456789 --log
+
+# View specific job
+gh run view 123456789 --job 987654321
+
+# View in browser
+gh run view 123456789 --web
+
+# Watch run in real-time
+gh run watch 123456789
+
+# Watch with interval
+gh run watch 123456789 --interval 5
+
+# Rerun failed run
+gh run rerun 123456789
+
+# Rerun specific job
+gh run rerun 123456789 --job 987654321
+
+# Cancel run
+gh run cancel 123456789
+
+# Delete run
+gh run delete 123456789
+
+# Download run artifacts
+gh run download 123456789
+
+# Download specific artifact
+gh run download 123456789 --name build
+
+# Download to directory
+gh run download 123456789 --dir ./artifacts
+```
+
+### Workflows (gh workflow)
+
+```bash
+# List workflows
+gh workflow list
+
+# View workflow details
+gh workflow view ci.yml
+
+# View workflow YAML
+gh workflow view ci.yml --yaml
+
+# View in browser
+gh workflow view ci.yml --web
+
+# Enable workflow
+gh workflow enable ci.yml
+
+# Disable workflow
+gh workflow disable ci.yml
+
+# Run workflow manually
+gh workflow run ci.yml
+
+# Run with inputs
+gh workflow run ci.yml \
+  --raw-field \
+  version="1.0.0" \
+  environment="production"
+
+# Run from specific branch
+gh workflow run ci.yml --ref develop
+```
+
+### Action Caches (gh cache)
+
+```bash
+# List caches
+gh cache list
+
+# List for specific branch
+gh cache list --branch main
+
+# List with limit
+gh cache list --limit 50
+
+# Delete cache
+gh cache delete 123456789
+
+# Delete all caches
+gh cache delete --all
+```
+
+### Action Secrets (gh secret)
+
+```bash
+# List secrets
+gh secret list
+
+# Set secret (prompts for value)
+gh secret set MY_SECRET
+
+# Set secret from environment
+echo "$MY_SECRET" | gh secret set MY_SECRET
+
+# Set secret for specific environment
+gh secret set MY_SECRET --env production
+
+# Set secret for organization
+gh secret set MY_SECRET --org orgname
+
+# Delete secret
+gh secret delete MY_SECRET
+
+# Delete from environment
+gh secret delete MY_SECRET --env production
+```
+
+### Action Variables (gh variable)
+
+```bash
+# List variables
+gh variable list
+
+# Set variable
+gh variable set MY_VAR "some-value"
+
+# Set variable for environment
+gh variable set MY_VAR "value" --env production
+
+# Set variable for organization
+gh variable set MY_VAR "value" --org orgname
+
+# Get variable value
+gh variable get MY_VAR
+
+# Delete variable
+gh variable delete MY_VAR
+
+# Delete from environment
+gh variable delete MY_VAR --env production
+```
+
+## Projects (gh project)
+
+```bash
+# List projects
+gh project list
+
+# List for owner
+gh project list --owner owner
+
+# Open projects
+gh project list --open
+
+# View project
+gh project view 123
+
+# View project items
+gh project view 123 --format json
+
+# Create project
+gh project create --title "My Project"
+
+# Create in organization
+gh project create --title "Project" --org orgname
+
+# Create with readme
+gh project create --title "Project" --readme "Description here"
+
+# Edit project
+gh project edit 123 --title "New Title"
+
+# Delete project
+gh project delete 123
+
+# Close project
+gh project close 123
+
+# Copy project
+gh project copy 123 --owner target-owner --title "Copy"
+
+# Mark template
+gh project mark-template 123
+
+# List fields
+gh project field-list 123
+
+# Create field
+gh project field-create 123 --title "Status" --datatype single_select
+
+# Delete field
+gh project field-delete 123 --id 456
+
+# List items
+gh project item-list 123
+
+# Create item
+gh project item-create 123 --title "New item"
+
+# Add item to project
+gh project item-add 123 --owner-owner --repo repo --issue 456
+
+# Edit item
+gh project item-edit 123 --id 456 --title "Updated title"
+
+# Delete item
+gh project item-delete 123 --id 456
+
+# Archive item
+gh project item-archive 123 --id 456
+
+# Link items
+gh project link 123 --id 456 --link-id 789
+
+# Unlink items
+gh project unlink 123 --id 456 --link-id 789
+
+# View project in browser
+gh project view 123 --web
+```
+
+## Releases (gh release)
+
+```bash
+# List releases
+gh release list
+
+# View latest release
+gh release view
+
+# View specific release
+gh release view v1.0.0
+
+# View in browser
+gh release view v1.0.0 --web
+
+# Create release
+gh release create v1.0.0 \
+  --notes "Release notes here"
+
+# Create release with notes from file
+gh release create v1.0.0 --notes-file notes.md
+
+# Create release with target
+gh release create v1.0.0 --target main
+
+# Create release as draft
+gh release create v1.0.0 --draft
+
+# Create pre-release
+gh release create v1.0.0 --prerelease
+
+# Create release with title
+gh release create v1.0.0 --title "Version 1.0.0"
+
+# Upload asset to release
+gh release upload v1.0.0 ./file.tar.gz
+
+# Upload multiple assets
+gh release upload v1.0.0 ./file1.tar.gz ./file2.tar.gz
+
+# Upload with label (casing sensitive)
+gh release upload v1.0.0 ./file.tar.gz --casing
+
+# Delete release
+gh release delete v1.0.0
+
+# Delete with cleanup tag
+gh release delete v1.0.0 --yes
+
+# Delete specific asset
+gh release delete-asset v1.0.0 file.tar.gz
+
+# Download release assets
+gh release download v1.0.0
+
+# Download specific asset
+gh release download v1.0.0 --pattern "*.tar.gz"
+
+# Download to directory
+gh release download v1.0.0 --dir ./downloads
+
+# Download archive (zip/tar)
+gh release download v1.0.0 --archive zip
+
+# Edit release
+gh release edit v1.0.0 --notes "Updated notes"
+
+# Verify release signature
+gh release verify v1.0.0
+
+# Verify specific asset
+gh release verify-asset v1.0.0 file.tar.gz
+```
+
+## Gists (gh gist)
+
+```bash
+# List gists
+gh gist list
+
+# List all gists (including private)
+gh gist list --public
+
+# Limit results
+gh gist list --limit 20
+
+# View gist
+gh gist view abc123
+
+# View gist files
+gh gist view abc123 --files
+
+# Create gist
+gh gist create script.py
+
+# Create gist with description
+gh gist create script.py --desc "My script"
+
+# Create public gist
+gh gist create script.py --public
+
+# Create multi-file gist
+gh gist create file1.py file2.py
+
+# Create from stdin
+echo "print('hello')" | gh gist create
+
+# Edit gist
+gh gist edit abc123
+
+# Delete gist
+gh gist delete abc123
+
+# Rename gist file
+gh gist rename abc123 --filename old.py new.py
+
+# Clone gist
+gh gist clone abc123
+
+# Clone to directory
+gh gist clone abc123 my-directory
+```
+
+## Codespaces (gh codespace)
+
+```bash
+# List codespaces
+gh codespace list
+
+# Create codespace
+gh codespace create
+
+# Create with specific repository
+gh codespace create --repo owner/repo
+
+# Create with branch
+gh codespace create --branch develop
+
+# Create with specific machine
+gh codespace create --machine premiumLinux
+
+# View codespace details
+gh codespace view
+
+# SSH into codespace
+gh codespace ssh
+
+# SSH with specific command
+gh codespace ssh --command "cd /workspaces && ls"
+
+# Open codespace in browser
+gh codespace code
+
+# Open in VS Code
+gh codespace code --codec
+
+# Open with specific path
+gh codespace code --path /workspaces/repo
+
+# Stop codespace
+gh codespace stop
+
+# Delete codespace
+gh codespace delete
+
+# View logs
+gh codespace logs
+
+--tail 100
+
+# View ports
+gh codespace ports
+
+# Forward port
+gh codespace cp 8080:8080
+
+# Rebuild codespace
+gh codespace rebuild
+
+# Edit codespace
+gh codespace edit --machine standardLinux
+
+# Jupyter support
+gh codespace jupyter
+
+# Copy files to/from codespace
+gh codespace cp file.txt :/workspaces/file.txt
+gh codespace cp :/workspaces/file.txt ./file.txt
+```
+
+## Organizations (gh org)
+
+```bash
+# List organizations
+gh org list
+
+# List for user
+gh org list --user username
+
+# JSON output
+gh org list --json login,name,description
+
+# View organization
+gh org view orgname
+
+# View organization members
+gh org view orgname --json members --jq '.members[] | .login'
+```
+
+## Search (gh search)
+
+```bash
+# Search code
+gh search code "TODO"
+
+# Search in specific repository
+gh search code "TODO" --repo owner/repo
+
+# Search commits
+gh search commits "fix bug"
+
+# Search issues
+gh search issues "label:bug state:open"
+
+# Search PRs
+gh search prs "is:open is:pr review:required"
+
+# Search repositories
+gh search repos "stars:>1000 language:python"
+
+# Limit results
+gh search repos "topic:api" --limit 50
+
+# JSON output
+gh search repos "stars:>100" --json name,description,stargazers
+
+# Order results
+gh search repos "language:rust" --order desc --sort stars
+
+# Search with extensions
+gh search code "import" --extension py
+
+# Web search (open in browser)
+gh search prs "is:open" --web
+```
+
+## Labels (gh label)
+
+```bash
+# List labels
+gh label list
+
+# Create label
+gh label create bug --color "d73a4a" --description "Something isn't working"
+
+# Create with hex color
+gh label create enhancement --color "#a2eeef"
+
+# Edit label
+gh label edit bug --name "bug-report" --color "ff0000"
+
+# Delete label
+gh label delete bug
+
+# Clone labels from repository
+gh label clone owner/repo
+
+# Clone to specific repository
+gh label clone owner/repo --repo target/repo
+```
+
+## SSH Keys (gh ssh-key)
+
+```bash
+# List SSH keys
+gh ssh-key list
+
+# Add SSH key
+gh ssh-key add ~/.ssh/id_rsa.pub --title "My laptop"
+
+# Add key with type
+gh ssh-key add ~/.ssh/id_ed25519.pub --type "authentication"
+
+# Delete SSH key
+gh ssh-key delete 12345
+
+# Delete by title
+gh ssh-key delete --title "My laptop"
+```
+
+## GPG Keys (gh gpg-key)
+
+```bash
+# List GPG keys
+gh gpg-key list
+
+# Add GPG key
+gh gpg-key add ~/.ssh/id_rsa.pub
+
+# Delete GPG key
+gh gpg-key delete 12345
+
+# Delete by key ID
+gh gpg-key delete ABCD1234
+```
+
+## Status (gh status)
+
+```bash
+# Show status overview
+gh status
+
+# Status for specific repositories
+gh status --repo owner/repo
+
+# JSON output
+gh status --json
+```
+
+## Configuration (gh config)
+
+```bash
+# List all config
+gh config list
+
+# Get specific value
+gh config get editor
+
+# Set value
+gh config set editor vim
+
+# Set git protocol
+gh config set git_protocol ssh
+
+# Clear cache
+gh config clear-cache
+
+# Set prompt behavior
+gh config set prompt disabled
+gh config set prompt enabled
+```
+
+## Extensions (gh extension)
+
+```bash
+# List installed extensions
+gh extension list
+
+# Search extensions
+gh extension search github
+
+# Install extension
+gh extension install owner/extension-repo
+
+# Install from branch
+gh extension install owner/extension-repo --branch develop
+
+# Upgrade extension
+gh extension upgrade extension-name
+
+# Remove extension
+gh extension remove extension-name
+
+# Create new extension
+gh extension create my-extension
+
+# Browse extensions
+gh extension browse
+
+# Execute extension command
+gh extension exec my-extension --arg value
+```
+
+## Aliases (gh alias)
+
+```bash
+# List aliases
+gh alias list
+
+# Set alias
+gh alias set prview 'pr view --web'
+
+# Set shell alias
+gh alias set co 'pr checkout' --shell
+
+# Delete alias
+gh alias delete prview
+
+# Import aliases
+gh alias import ./aliases.sh
+```
+
+## API Requests (gh api)
+
+```bash
+# Make API request
+gh api /user
+
+# Request with method
+gh api --method POST /repos/owner/repo/issues \
+  --field title="Issue title" \
+  --field body="Issue body"
+
+# Request with headers
+gh api /user \
+  --header "Accept: application/vnd.github.v3+json"
+
+# Request with pagination
+gh api /user/repos --paginate
+
+# Raw output (no formatting)
+gh api /user --raw
+
+# Include headers in output
+gh api /user --include
+
+# Silent mode (no progress output)
+gh api /user --silent
+
+# Input from file
+gh api --input request.json
+
+# jq query on response
+gh api /user --jq '.login'
+
+# Field from response
+gh api /repos/owner/repo --jq '.stargazers_count'
+
+# GitHub Enterprise
+gh api /user --hostname enterprise.internal
+
+# GraphQL query
+gh api graphql \
+  -f query='
+  {
+    viewer {
+      login
+      repositories(first: 5) {
+        nodes {
+          name
+        }
+      }
+    }
+  }'
+```
+
+## Rulesets (gh ruleset)
+
+```bash
+# List rulesets
+gh ruleset list
+
+# View ruleset
+gh ruleset view 123
+
+# Check ruleset
+gh ruleset check --branch feature
+
+# Check specific repository
+gh ruleset check --repo owner/repo --branch main
+```
+
+## Attestations (gh attestation)
+
+```bash
+# Download attestation
+gh attestation download owner/repo \
+  --artifact-id 123456
+
+# Verify attestation
+gh attestation verify owner/repo
+
+# Get trusted root
+gh attestation trusted-root
+```
+
+## Completion (gh completion)
+
+```bash
+# Generate shell completion
+gh completion -s bash > ~/.gh-complete.bash
+gh completion -s zsh > ~/.gh-complete.zsh
+gh completion -s fish > ~/.gh-complete.fish
+gh completion -s powershell > ~/.gh-complete.ps1
+
+# Shell-specific instructions
+gh completion --shell=bash
+gh completion --shell=zsh
+```
+
+## Preview (gh preview)
+
+```bash
+# List preview features
+gh preview
+
+# Run preview script
+gh preview prompter
+```
+
+## Agent Tasks (gh agent-task)
+
+```bash
+# List agent tasks
+gh agent-task list
+
+# View agent task
+gh agent-task view 123
+
+# Create agent task
+gh agent-task create --description "My task"
+```
+
+## Global Flags
+
+| Flag                       | Description                            |
+| -------------------------- | -------------------------------------- |
+| `--help` / `-h`            | Show help for command                  |
+| `--version`                | Show gh version                        |
+| `--repo [HOST/]OWNER/REPO` | Select another repository              |
+| `--hostname HOST`          | GitHub hostname                        |
+| `--jq EXPRESSION`          | Filter JSON output                     |
+| `--json FIELDS`            | Output JSON with specified fields      |
+| `--template STRING`        | Format JSON using Go template          |
+| `--web`                    | Open in browser                        |
+| `--paginate`               | Make additional API calls              |
+| `--verbose`                | Show verbose output                    |
+| `--debug`                  | Show debug output                      |
+| `--timeout SECONDS`        | Maximum API request duration           |
+| `--cache CACHE`            | Cache control (default, force, bypass) |
+
+## Output Formatting
+
+### JSON Output
+
+```bash
+# Basic JSON
+gh repo view --json name,description
+
+# Nested fields
+gh repo view --json owner,name --jq '.owner.login + "/" + .name'
+
+# Array operations
+gh pr list --json number,title --jq '.[] | select(.number > 100)'
+
+# Complex queries
+gh issue list --json number,title,labels \
+  --jq '.[] | {number, title: .title, tags: [.labels[].name]}'
+```
+
+### Template Output
+
+```bash
+# Custom template
+gh repo view \
+  --template '{{.name}}: {{.description}}'
+
+# Multiline template
+gh pr view 123 \
+  --template 'Title: {{.title}}
+Author: {{.author.login}}
+State: {{.state}}
+'
+```
+
+## Common Workflows
+
+### Create PR from Issue
+
+```bash
+# Create branch from issue
+gh issue develop 123 --branch feature/issue-123
+
+# Make changes, commit, push
+git add .
+git commit -m "Fix issue #123"
+git push
+
+# Create PR linking to issue
+gh pr create --title "Fix #123" --body "Closes #123"
+```
+
+### Bulk Operations
+
+```bash
+# Close multiple issues
+gh issue list --search "label:stale" \
+  --json number \
+  --jq '.[].number' | \
+  xargs -I {} gh issue close {} --comment "Closing as stale"
+
+# Add label to multiple PRs
+gh pr list --search "review:required" \
+  --json number \
+  --jq '.[].number' | \
+  xargs -I {} gh pr edit {} --add-label needs-review
+```
+
+### Repository Setup Workflow
+
+```bash
+# Create repository with initial setup
+gh repo create my-project --public \
+  --description "My awesome project" \
+  --clone \
+  --gitignore python \
+  --license mit
+
+cd my-project
+
+# Set up branches
+git checkout -b develop
+git push -u origin develop
+
+# Create labels
+gh label create bug --color "d73a4a" --description "Bug report"
+gh label create enhancement --color "a2eeef" --description "Feature request"
+gh label create documentation --color "0075ca" --description "Documentation"
+```
+
+### CI/CD Workflow
+
+```bash
+# Run workflow and wait
+RUN_ID=$(gh workflow run ci.yml --ref main --jq '.databaseId')
+
+# Watch the run
+gh run watch "$RUN_ID"
+
+# Download artifacts on completion
+gh run download "$RUN_ID" --dir ./artifacts
+```
+
+### Fork Sync Workflow
+
+```bash
+# Fork repository
+gh repo fork original/repo --clone
+
+cd repo
+
+# Add upstream remote
+git remote add upstream https://github.com/original/repo.git
+
+# Sync fork
+gh repo sync
+
+# Or manual sync
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+## Environment Setup
+
+### Shell Integration
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+eval "$(gh completion -s bash)"  # or zsh/fish
+
+# Create useful aliases
+alias gs='gh status'
+alias gpr='gh pr view --web'
+alias gir='gh issue view --web'
+alias gco='gh pr checkout'
+```
+
+### Git Configuration
+
+```bash
+# Use gh as credential helper
+gh auth setup-git
+
+# Set gh as default for repo operations
+git config --global credential.helper 'gh !gh auth setup-git'
+
+# Or manually
+git config --global credential.helper github
+```
+
+## Best Practices
+
+1. **Authentication**: Use environment variables for automation
+
+   ```bash
+   export GH_TOKEN=$(gh auth token)
+   ```
+
+2. **Default Repository**: Set default to avoid repetition
+
+   ```bash
+   gh repo set-default owner/repo
+   ```
+
+3. **JSON Parsing**: Use jq for complex data extraction
+
+   ```bash
+   gh pr list --json number,title --jq '.[] | select(.title | contains("fix"))'
+   ```
+
+4. **Pagination**: Use --paginate for large result sets
+
+   ```bash
+   gh issue list --state all --paginate
+   ```
+
+5. **Caching**: Use cache control for frequently accessed data
+   ```bash
+   gh api /user --cache force
+   ```
+
+## Getting Help
+
+```bash
+# General help
+gh --help
+
+# Command help
+gh pr --help
+gh issue create --help
+
+# Help topics
+gh help formatting
+gh help environment
+gh help exit-codes
+gh help accessibility
+```
+
+## References
+
+- Official Manual: https://cli.github.com/manual/
+- GitHub Docs: https://docs.github.com/en/github-cli
+- REST API: https://docs.github.com/en/rest
+- GraphQL API: https://docs.github.com/en/graphql

--- a/.agents/skills/gh-stack/SKILL.md
+++ b/.agents/skills/gh-stack/SKILL.md
@@ -1,0 +1,845 @@
+---
+description: |
+    Manage stacked branches and pull requests with the gh-stack GitHub CLI extension. Use when the user wants to create, push, rebase, sync, navigate, or view stacks of dependent PRs. Triggers on tasks involving stacked diffs, dependent pull requests, branch chains, or incremental code review workflows.
+metadata:
+    author: github
+    github-path: skills/gh-stack
+    github-ref: refs/tags/v0.0.2
+    github-repo: https://github.com/github/gh-stack
+    github-tree-sha: f11c787bea0bf060af1d8742464a22cd35aa1630
+    version: 0.0.2
+name: gh-stack
+---
+# gh-stack
+
+`gh stack` is a [GitHub CLI](https://cli.github.com/) extension for managing **stacked branches and pull requests**. A stack is an ordered list of branches where each branch builds on the one below it, rooted on a trunk branch (typically the repo's default branch). Each branch maps to one PR whose base is the branch below it, so reviewers see only the diff for that layer.
+
+```
+main (trunk)
+ └── feat/auth-layer     → PR #1 (base: main)               - bottom (closest to trunk)
+  └── feat/api-endpoints → PR #2 (base: feat/auth-layer)
+   └── feat/frontend     → PR #3 (base: feat/api-endpoints) - top (furthest from trunk)
+```
+
+The **bottom** of the stack is the branch closest to the trunk, and the **top** is the branch furthest from the trunk. Each branch inherits from the one below it. Navigation commands (`up`, `down`, `top`, `bottom`) follow this model: `up` moves away from trunk, `down` moves toward it.
+
+## When to use this skill
+
+Use this skill when the user wants to:
+
+- Break a large change into a chain of small, reviewable PRs
+- Create, rebase, push, or sync a stack of dependent branches
+- Navigate between layers of a branch stack
+- View the status of stacked PRs
+- Tear down and rebuild a stack to remove, reorder, or rename branches
+
+## Prerequisites
+
+The GitHub CLI (`gh`) v2.0+ must be installed and authenticated. Install the extension with:
+
+```bash
+gh extension install github/gh-stack
+```
+
+Before using `gh stack`, configure git to prevent interactive prompts:
+
+```bash
+git config rerere.enabled true           # remember conflict resolutions (skips prompt on init)
+git config remote.pushDefault origin     # if multiple remotes exist (skips remote picker)
+```
+
+## Agent rules
+
+**All `gh stack` commands must be run non-interactively.** Every command invocation must include the flags and positional arguments needed to avoid prompts, TUIs, and interactive menus. If a command would prompt for input, it will hang indefinitely.
+
+1. **Always supply branch names as positional arguments** to `init`, `add`, and `checkout`. Running these commands without arguments triggers interactive prompts.
+2. **When a prefix is set, pass only the suffix to `add`.** `gh stack add auth` with prefix `feat` → `feat/auth`. Passing `feat/auth` creates `feat/feat/auth`.
+3. **Always use `--auto` with `gh stack submit`** to auto-generate PR titles. Without `--auto`, `submit` prompts for a title for each new PR.
+4. **Always use `--json` with `gh stack view`.** Without `--json`, the command launches an interactive TUI that cannot be operated by agents. There is no other appropriate flag — always pass `--json`.
+5. **Use `--remote <name>` when multiple remotes are configured**, or pre-configure `git config remote.pushDefault origin`. Without this, `push`, `submit`, `sync`, `link`, and `checkout` trigger an interactive remote picker.
+6. **Avoid branches shared across multiple stacks.** If a branch belongs to multiple stacks, commands exit with code 6. Check out a non-shared branch first.
+7. **Plan your stack layers by dependency order before writing code.** Foundational changes (models, APIs, shared utilities) go in lower branches; dependent changes (UI, consumers) go in higher branches. Think through the dependency chain before running `gh stack init`.
+8. **Use standard `git add` and `git commit` for staging and committing.** This gives you full control over which changes go into each branch. The `-Am` shortcut is available but should not be the default approach—stacked PRs are most effective when each branch contains a deliberate, logical set of changes.
+9. **Navigate down the stack when you need to change a lower layer.** If you're working on a frontend branch and realize you need API changes, don't hack around it at the current layer. Navigate to the appropriate branch (`gh stack down`, `gh stack checkout`, or `gh stack bottom`), make and commit the changes there, run `gh stack rebase --upstack`, then navigate back up to continue.
+10. **Use `gh stack link` for external tool workflows.** When branches are managed by an external tool (jj, Sapling, etc.), use `gh stack link branch-a branch-b`. `link` does not rely on local tracking state and is intended for API-driven PR and stack management. Always provide at least 2 branch names or PR numbers.
+
+**Never do any of the following — each triggers an interactive prompt or TUI that will hang:**
+- ❌ `gh stack view` or `gh stack view --short` — always use `gh stack view --json`
+- ❌ `gh stack submit` without `--auto` — always use `gh stack submit --auto`
+- ❌ `gh stack init` without branch arguments — always provide branch names
+- ❌ `gh stack add` without a branch name — always provide a branch name
+- ❌ `gh stack checkout` without an argument — always provide a PR number or branch name
+- ❌ `gh stack checkout <pr-number>` when a different local stack already exists on those branches — this triggers an unbypassable conflict resolution prompt; use `gh stack unstack` first to remove the local stack, then retry the checkout
+
+## Thinking about stack structure
+
+Each branch in a stack should represent a **discrete, logical unit of work** that can be reviewed independently. The changes within a branch should be cohesive—they belong together and make sense as a single PR.
+
+### Dependency chain
+
+Stacked branches form a dependency chain: each branch builds on the one below it. This means **foundational changes must go in lower (earlier) branches**, and code that depends on them goes in higher (later) branches.
+
+**Plan your layers before writing code.** For example, a full-stack feature might be structured like this (use branch names relevant to your actual task, not these generic ones):
+
+```
+main (trunk)
+ └── feat/data-models    ← shared types, database schema
+  └── feat/api-endpoints ← API routes that use the models
+   └── feat/frontend-ui  ← UI components that call the APIs
+    └── feat/integration ← tests that exercise the full stack
+```
+
+This is illustrative — choose branch names and layer boundaries that reflect the specific work you're doing. The key principle is: if code in one layer depends on code in another, the dependency must be in the same branch or a lower one.
+
+### Branch naming
+
+Prefer initializing stacks with a prefix (`-p`). Prefixes group branches under a namespace (e.g., `feat/auth`, `feat/api`) and keep branch names clean and consistent. When a prefix is set, pass only the suffix to subsequent `add` calls — the prefix is applied automatically. Without a prefix, you'll need to pass the full branch name each time.
+
+### Staging changes deliberately
+
+The main reason to use `git add` and `git commit` directly is to control **which changes go into which branch**. When you have multiple files in your working tree, you can stage a subset for the current branch, commit them, then create a new branch and stage the rest there:
+
+```bash
+# You're on feat/data-models with several new files in your working tree.
+# Stage only the model files for this branch:
+git add internal/models/user.go internal/models/session.go
+git commit -m "Add user and session models"
+
+git add db/migrations/001_create_users.sql
+git commit -m "Add user table migration"
+
+# Now create a new branch for the API layer and stage the API files there:
+gh stack add api-routes # created & switched to feat/api-routes branch
+git add internal/api/routes.go internal/api/handlers.go
+git commit -m "Add user API routes"
+```
+
+This keeps each branch focused on one concern. Multiple commits per branch are fine — the key is that all commits in a branch relate to the same logical concern, and changes that belong to a different concern go in a different branch.
+
+### When to create a new branch
+
+Create a new branch (`gh stack add`) when you're starting a **different concern** that depends on what you've built so far. Signs it's time for a new branch:
+
+- You're switching from backend to frontend work
+- You're moving from core logic to tests or documentation
+- The next set of changes has a different reviewer audience
+- The current branch's PR is already large enough to review
+
+### One stack, one story
+
+Think of a stack from the reviewer's perspective: the stack of PRs should **tell a cohesive story** about a feature or project. A reviewer should be able to read the PRs in sequence and understand the progression of changes, with each PR being a small, logical piece of the whole.
+
+**When to use a single stack:** All the branches are part of the same feature, project, or closely related effort. Even if the work spans multiple concerns (models, API, frontend), they're all building toward the same goal.
+
+**When to create a separate stack:** The work is unrelated to your current stack — a different feature, a bug fix in an unrelated area, or an independent refactor. Don't mix unrelated work into a single stack just because you happen to be working on both. Start a new stack with `gh stack init` or switch to an existing stack with `gh stack checkout` for each distinct effort.
+
+Small, incidental fixes (e.g., fixing a typo you noticed) can go in the current stack if they're trivial. But if a change grows into its own project, it deserves its own stack.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Create a stack (recommended) | `gh stack init -p feat auth` |
+| Create a stack without prefix | `gh stack init auth` |
+| Adopt existing branches | `gh stack init --adopt branch-a branch-b` |
+| Set custom trunk | `gh stack init --base develop branch-a` |
+| Add a branch to stack (suffix only if prefix set) | `gh stack add api-routes` |
+| Add branch + stage all + commit | `gh stack add -Am "message" api-routes` |
+| Push branches to remote | `gh stack push` |
+| Push to specific remote | `gh stack push --remote origin` |
+| Push branches + create PRs | `gh stack submit --auto` |
+| Create PRs as drafts | `gh stack submit --auto --draft` |
+| Sync (fetch, rebase, push) | `gh stack sync` |
+| Sync with specific remote | `gh stack sync --remote origin` |
+| Rebase entire stack | `gh stack rebase` |
+| Rebase upstack only | `gh stack rebase --upstack` |
+| Continue after conflict | `gh stack rebase --continue` |
+| Abort rebase | `gh stack rebase --abort` |
+| View stack details (JSON) | `gh stack view --json` |
+| Switch branches up/down in stack | `gh stack up [n]` / `gh stack down [n]` |
+| Switch to top/bottom branch | `gh stack top` / `gh stack bottom` |
+| Check out by PR | `gh stack checkout 42` |
+| Check out by branch (local only) | `gh stack checkout feature-auth` |
+| Tear down a stack to restructure it | `gh stack unstack` |
+
+---
+
+## Workflows
+
+### End-to-end: create a stack from scratch
+
+```bash
+# 1. Initialize a stack with the first branch
+gh stack init -p feat auth
+# → creates feat/auth and checks it out
+
+# 2. Write code for the first layer (auth)
+cat > auth.go << 'EOF'
+package auth
+
+func Middleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // verify token
+        next.ServeHTTP(w, r)
+    })
+}
+EOF
+
+# 3. Stage and commit using standard git commands
+git add auth.go
+git commit -m "Add auth middleware"
+
+# You can make multiple commits on the same branch
+cat > auth_test.go << 'EOF'
+package auth
+
+func TestMiddleware(t *testing.T) {
+    // test auth middleware
+}
+EOF
+git add auth_test.go
+git commit -m "Add auth middleware tests"
+
+# 4. When you're ready for a new concern, add the next branch
+gh stack add api-routes
+# → creates feat/api-routes (prefix applied automatically — just pass the suffix)
+
+# 5. Write code for the API layer
+cat > api.go << 'EOF'
+package api
+
+func RegisterRoutes(mux *http.ServeMux) {
+    mux.HandleFunc("/users", handleUsers)
+}
+EOF
+git add api.go
+git commit -m "Add API routes"
+
+# 6. Add a third layer for frontend
+gh stack add frontend
+# → creates feat/frontend (just the suffix — prefix is automatic)
+
+cat > frontend.go << 'EOF'
+package frontend
+
+func RenderDashboard(w http.ResponseWriter) {
+    // calls the API endpoints from the layer below
+}
+EOF
+git add frontend.go
+git commit -m "Add frontend dashboard"
+
+# ── Stack complete: feat/auth → feat/api-routes → feat/frontend ──
+
+# 7. Push everything and create draft PRs
+gh stack submit --auto --draft
+
+# 8. Verify the stack
+gh stack view --json
+```
+
+> **Shortcut:** If you prefer a faster flow, `gh stack add -Am "message" branch-name` combines staging, committing, and branch creation into one command. This is useful for single-commit layers but bypasses deliberate staging.
+
+### Making mid-stack changes
+
+This is a critical workflow for agents. When you're working on a higher layer and realize you need to change something in a lower layer (e.g., you're building frontend components but need to add an API endpoint), **navigate down to the correct branch, make the change there, and rebase**.
+
+```bash
+# You're on feat/frontend but need to add an API endpoint
+
+# 1. Navigate to the API branch
+gh stack down
+# or: gh stack checkout feat/api-routes
+
+# 2. Make the change where it belongs
+cat > users_api.go << 'EOF'
+package api
+
+func handleGetUser(w http.ResponseWriter, r *http.Request) {
+    // new endpoint the frontend needs
+}
+EOF
+git add users_api.go
+git commit -m "Add get-user endpoint"
+
+# 3. Rebase everything above to pick up the change
+gh stack rebase --upstack
+
+# 4. Navigate back to where you were working
+gh stack top
+# or: gh stack checkout feat/frontend
+
+# 5. Continue working — the API changes are now available
+```
+
+**Why this matters:** If you make API changes on the frontend branch, those changes will end up in the wrong PR. The API PR won't include them, and the frontend PR will have unrelated API diffs mixed in. Always put changes in the branch where they logically belong.
+
+### Modify a mid-stack branch and sync
+
+When you need to revisit a branch after the initial creation (e.g., responding to review feedback):
+
+```bash
+# 1. Navigate to the branch that needs changes
+gh stack bottom
+# or: gh stack checkout feat/auth
+# or: gh stack checkout 42  (by PR number)
+
+# 2. Make changes and commit
+cat > auth.go << 'EOF'
+package auth
+// updated implementation
+EOF
+git add auth.go
+git commit -m "Fix auth token validation"
+
+# 3. Rebase everything above this branch
+gh stack rebase --upstack
+
+# 4. Push the updated stack
+gh stack push
+```
+
+### Routine sync after merges
+
+```bash
+# Single command: fetch, rebase, push, sync PR state
+gh stack sync
+```
+
+### Squash-merge recovery
+
+When a PR is squash-merged on GitHub, the original branch's commits no longer exist in the trunk history. `gh stack` detects this automatically and uses `git rebase --onto` to correctly replay remaining commits.
+
+```bash
+# After PR #1 (feat/auth) is squash-merged on GitHub:
+gh stack sync
+# → fetches latest, detects the merge, fast-forwards trunk
+# → rebases feat/api-routes onto updated trunk (skips merged branch)
+# → rebases feat/frontend onto feat/api-routes
+# → pushes updated branches
+# → reports: "Merged: #1"
+
+# Verify the result
+gh stack view --json
+# → feat/auth shows "isMerged": true, "state": "MERGED"
+# → feat/api-routes and feat/frontend show updated heads
+```
+
+If `sync` hits a conflict during this process, it restores all branches to their pre-rebase state and exits with code 3. See [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) for the resolution workflow.
+
+### Handle rebase conflicts (agent workflow)
+
+```bash
+# 1. Start the rebase
+gh stack rebase
+
+# 2. If exit code 3 (conflict):
+#    - Parse stderr for conflicted file paths
+#    - Read those files to find <<<<<<< / ======= / >>>>>>> markers
+#    - Edit files to resolve conflicts
+#    - Stage resolved files:
+git add path/to/resolved-file.go
+
+# 3. Continue the rebase
+gh stack rebase --continue
+
+# 4. If another conflict occurs, repeat steps 2-3
+
+# 5. If unable to resolve, abort to restore everything
+gh stack rebase --abort
+```
+
+### Parsing `--json` output
+
+```bash
+# Get stack state as JSON
+output=$(gh stack view --json)
+
+# Check if any branch needs a rebase, and rebase if so
+needs_rebase=$(echo "$output" | jq '[.branches[] | select(.needsRebase == true)] | length')
+if [ "$needs_rebase" -gt 0 ]; then
+  echo "Branches need rebase, rebasing stack..."
+  gh stack rebase
+fi
+
+# Get all open PR URLs
+echo "$output" | jq -r '.branches[] | select(.pr.state == "OPEN") | .pr.url'
+
+# Find merged branches
+echo "$output" | jq -r '.branches[] | select(.isMerged == true) | .name'
+
+# Get the current branch
+echo "$output" | jq -r '.currentBranch'
+
+# Check if the stack is fully merged (all branches merged)
+echo "$output" | jq '[.branches[] | .isMerged] | all'
+```
+
+### Restructure a stack (remove a branch, reorder, or rename)
+
+Use `unstack` to tear down the stack, make structural changes, then re-init:
+
+```bash
+# 1. Remove the stack (locally and on GitHub)
+gh stack unstack
+
+# 2. Make structural changes — e.g. delete a branch, reorder, rename
+git branch -m old-branch-1 new-branch-1
+
+# 3. Re-create the stack with the new structure
+gh stack init --base main --adopt new-branch-1 new-branch-2 new-branch-3
+```
+
+---
+
+## Commands
+
+### Initialize a stack — `gh stack init`
+
+Creates a new stack. **Always provide at least one branch name as a positional argument** — running without branch arguments triggers interactive prompts that agents cannot use.
+
+```
+gh stack init [flags] <branches...>
+```
+
+```bash
+# Set a branch prefix (recommended — subsequent `add` calls only need the suffix)
+gh stack init -p feat auth
+# → creates feat/auth
+
+# Multi-part prefix (slashes are fine — suffix-only rule still applies)
+gh stack init -p monalisa/billing auth
+# → creates monalisa/billing/auth
+
+# Create a stack with new branches (no prefix — use full branch names)
+gh stack init branch-a branch-b branch-c
+
+# Use a different trunk branch
+gh stack init --base develop branch-a branch-b
+
+# Adopt existing branches into a stack
+gh stack init --adopt branch-a branch-b branch-c
+```
+
+| Flag | Description |
+|------|-------------|
+| `-b, --base <branch>` | Trunk branch (defaults to the repo's default branch) |
+| `-a, --adopt` | Adopt existing branches instead of creating new ones |
+| `-p, --prefix <string>` | Branch name prefix. Subsequent `add` calls only need the suffix (e.g., with `-p feat`, `gh stack add auth` creates `feat/auth`) |
+
+**Behavior:**
+
+- Using `-p` is recommended — it simplifies branch naming for subsequent `add` calls
+- Creates any branches that don't already exist (branching from the trunk branch)
+- In `--adopt` mode: validates all branches exist, rejects if any is already in a stack or has an existing PR
+- Checks out the last branch in the list
+- Enables `git rerere` so conflict resolutions are remembered across rebases. On first run in a repo, this may trigger a confirmation prompt — pre-configure with `git config rerere.enabled true` to avoid it
+
+---
+
+### Add a branch — `gh stack add`
+
+Add a new branch on top of the current stack. Must be run while on the topmost branch (or the trunk if the stack has no branches yet). **Always provide a branch name** — running without one triggers an interactive prompt.
+
+```
+gh stack add [flags] <branch>
+```
+
+**Recommended workflow — create the branch, then use standard git:**
+
+```bash
+# Create a new branch and switch to it (just the suffix — prefix is applied automatically)
+gh stack add api-routes
+
+# Write code, stage deliberately, and commit
+git add internal/api/routes.go internal/api/handlers.go
+git commit -m "Add user API routes"
+
+# Make more commits on the same branch as needed
+git add internal/api/middleware.go
+git commit -m "Add rate limiting middleware"
+```
+
+**Shortcut — stage, commit, and branch in one command:**
+
+```bash
+# Create a new branch, stage all changes, and commit
+gh stack add -Am "Add API routes" api-routes
+
+# Create a new branch, stage tracked files only, and commit
+gh stack add -um "Fix auth bug" auth-fix
+```
+
+| Flag | Description |
+|------|-------------|
+| `-m, --message <string>` | Create a commit with this message |
+| `-A, --all` | Stage all changes including untracked files (requires `-m`) |
+| `-u, --update` | Stage tracked files only (requires `-m`) |
+
+**Behavior notes:**
+
+- `-A` and `-u` are mutually exclusive.
+- When the current branch has no commits (e.g., right after `init`), `add -Am` commits directly on the current branch instead of creating a new one.
+- **Prefix handling:** Only pass the suffix when a prefix is set. `gh stack add api` with prefix `todo` → `todo/api`. Passing `todo/api` creates `todo/todo/api`. Without a prefix, pass the full branch name.
+- If called from a branch that is not the topmost in the stack, exits with code 5: `"can only add branches on top of the stack"`. Use `gh stack top` to switch first.
+- **Uncommitted changes:** When using `gh stack add branch-name` without `-Am`, any uncommitted changes (staged or unstaged) in your working tree carry over to the new branch. This is standard git behavior — the working tree is not touched. Commit or stash changes on the current branch before running `add` if you want a clean starting point on the new branch.
+
+---
+
+### Push branches to remote — `gh stack push`
+
+Push all stack branches to the remote.
+
+```
+gh stack push [flags]
+```
+
+```bash
+# Push all branches
+gh stack push
+
+# Push to specific remote
+gh stack push --remote upstream
+```
+
+| Flag | Description |
+|------|-------------|
+| `--remote <name>` | Remote to push to (use if multiple remotes exist) |
+
+**Behavior:**
+
+- Pushes all active (non-merged) branches atomically (`--force-with-lease --atomic`)
+- Does **not** create or update pull requests — use `gh stack submit` for that
+
+**Output (stderr):**
+
+- `Pushed N branches` summary
+
+---
+
+### Submit branches and create PRs — `gh stack submit`
+
+Push all stack branches and create PRs on GitHub. **Always pass `--auto`** — without it, `submit` prompts for a PR title for each new branch.
+
+```bash
+# Submit and auto-title new PRs (required for non-interactive use)
+gh stack submit --auto
+
+# Submit and create PRs as drafts
+gh stack submit --auto --draft
+```
+
+| Flag | Description |
+|------|-------------|
+| `--auto` | Auto-generate PR titles without prompting (**required** for non-interactive use) |
+| `--draft` | Create new PRs as drafts |
+| `--remote <name>` | Remote to push to (use if multiple remotes exist) |
+
+**Behavior:**
+
+- Pushes all active (non-merged) branches atomically (`--force-with-lease --atomic`)
+- Creates a new PR for each branch that doesn't have one (base set to the first non-merged ancestor branch)
+- After creating PRs, links them together as a **Stack** on GitHub (requires the repository to have stacks enabled)
+- If stacks are not available (exit code 9), the repository does not have stacked PRs enabled. In interactive mode, `submit` offers to create regular (unstacked) PRs instead. In non-interactive mode, it exits with code 9.
+- Syncs PR metadata for branches that already have PRs
+
+**PR title auto-generation (`--auto`):**
+
+- Single commit on branch → uses the commit subject as the PR title, commit body as PR body
+- Multiple commits on branch → humanizes the branch name (hyphens/underscores → spaces) as the title
+
+**Output (stderr):**
+
+- `Created PR #N for <branch>` for each newly created PR
+- `PR #N for <branch> is up to date` for existing PRs
+- `Pushed and synced N branches` summary
+
+---
+
+### Link branches as a stack (no local tracking) — `gh stack link`
+
+Link PRs into a stack on GitHub without creating any local tracking state. This is the recommended approach if you are managing stacked branches with other tools (jj, Sapling, git-town) and want to simply create GitHub Stacked PRs via an API.
+
+```
+gh stack link [flags] <branch-or-pr> <branch-or-pr> [...]
+```
+
+```bash
+# Link branches into a stack (pushes, creates PRs, creates stack)
+gh stack link branch-a branch-b branch-c
+
+# Use a different base branch and create PRs as drafts
+gh stack link --base develop --draft branch-a branch-b branch-c
+
+# Link existing PRs by number
+gh stack link 10 20 30
+
+# Add branches to an existing stack of PRs
+gh stack link 42 43 feature-auth feature-ui
+```
+
+| Flag | Description |
+|------|---------|
+| `--base <branch>` | Base branch for the bottom of the stack (default: `main`) |
+| `--draft` | Create new PRs as drafts |
+| `--remote <name>` | Remote to push to (use if multiple remotes exist) |
+
+**Behavior:**
+
+- Arguments are provided in stack order (bottom to top)
+- Each argument can be a branch name or a PR number. Numeric arguments are tried as PR numbers first; if no PR with that number exists, the argument is treated as a branch name
+- Branch arguments are pushed to the remote automatically (non-force, atomic)
+- For branches without open PRs, new PRs are created with auto-generated titles and the correct base branch chaining (first branch uses `--base`, subsequent branches use the previous branch)
+- Existing PRs whose base branch doesn't match the expected chain are corrected automatically
+- If the PRs are not yet in a stack, a new stack is created. If some PRs are already in a stack, the stack is updated (additive only — existing PRs are never removed)
+- Does **not** create or modify any local state
+
+**Output (stderr):**
+
+- `Pushing N branches to <remote>...`
+- `Found PR #N for branch <name>` for branches with existing PRs
+- `Created PR #N for <branch> (base: <base>)` for newly created PRs
+- `Updated base branch for PR #N to <base>` when base branches are corrected
+- `Created stack with N PRs` or `Updated stack to N PRs`
+
+---
+
+### Sync the stack — `gh stack sync`
+
+Fetch, rebase, push, and sync PR state in a single command. This is the recommended command for routine synchronization.
+
+```
+gh stack sync [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--remote <name>` | Remote to fetch from and push to (use if multiple remotes exist) |
+
+**What it does (in order):**
+
+1. **Fetch** latest changes from the remote
+2. **Fast-forward trunk** to match remote (skips if already up to date, warns if diverged)
+3. **Cascade rebase** all stack branches onto their updated parents (only if trunk moved). Handles merged PRs automatically. If a conflict is detected, **all branches are restored** to their pre-rebase state and the command exits with code 3 — see [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) for the resolution workflow
+4. **Push** all active branches atomically
+5. **Sync PR state** from GitHub and report the status of each PR
+
+**Output (stderr):**
+
+- `✓ Fetched latest changes from origin`
+- `✓ Trunk main fast-forwarded to <sha>` or `✓ Trunk main is already up to date`
+- `✓ Rebased <branch> onto <base>` per branch (if base moved)
+- `✓ Pushed N branches`
+- `✓ PR #N (<branch>) — Open` per branch
+- `Merged: #N, #M` for merged branches
+- `✓ Stack synced`
+
+---
+
+### Rebase the stack — `gh stack rebase`
+
+Pull from remote and cascade-rebase stack branches. Use this when `sync` reports a conflict or when you need finer control (e.g., rebase only part of the stack).
+
+```
+gh stack rebase [flags] [branch]
+```
+
+```bash
+# Rebase the entire stack
+gh stack rebase
+
+# Rebase only branches from trunk to current branch
+gh stack rebase --downstack
+
+# Rebase only branches from current branch to top
+gh stack rebase --upstack
+
+# After resolving a conflict: stage files with `git add`, then:
+gh stack rebase --continue
+
+# Abort and restore all branches to pre-rebase state
+gh stack rebase --abort
+```
+
+| Flag | Description |
+|------|-------------|
+| `--downstack` | Only rebase branches from trunk to the current branch |
+| `--upstack` | Only rebase branches from the current branch to the top |
+| `--continue` | Continue after resolving conflicts |
+| `--abort` | Abort and restore all branches |
+| `--remote <name>` | Remote to fetch from (use if multiple remotes exist) |
+
+| Argument | Description |
+|----------|-------------|
+| `[branch]` | Target branch (defaults to the current branch) |
+
+**Conflict handling:** See [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) in the Workflows section for the full resolution workflow.
+
+**Merged PR detection:** If a branch's PR was merged on GitHub, the rebase automatically handles this using `--onto` mode and correctly replays commits on top of the merge target.
+
+**Rerere (conflict memory):** `git rerere` is enabled by `init` so previously resolved conflicts are auto-resolved in future rebases.
+
+---
+
+### View the stack — `gh stack view`
+
+Display the current stack's branches, PR status, and recent commits. **Always pass `--json`** — without it, this command launches an interactive TUI that agents cannot operate.
+
+```bash
+# Always use --json
+gh stack view --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output stack data as JSON to stdout (**required** for non-interactive use) |
+
+**`--json` output format:**
+
+```json
+{
+  "trunk": "main",
+  "prefix": "feat",
+  "currentBranch": "feat/api-routes",
+  "branches": [
+    {
+      "name": "feat/auth",
+      "head": "abc1234...",
+      "base": "def5678...",
+      "isCurrent": false,
+      "isMerged": true,
+      "needsRebase": false,
+      "pr": {
+        "number": 42,
+        "url": "https://github.com/owner/repo/pull/42",
+        "state": "MERGED"
+      }
+    },
+    {
+      "name": "feat/api-routes",
+      "head": "789abcd...",
+      "base": "abc1234...",
+      "isCurrent": true,
+      "isMerged": false,
+      "needsRebase": false,
+      "pr": {
+        "number": 43,
+        "url": "https://github.com/owner/repo/pull/43",
+        "state": "OPEN"
+      }
+    }
+  ]
+}
+```
+
+Fields per branch:
+- `name` — branch name
+- `head` — current HEAD SHA
+- `base` — parent branch's HEAD SHA at last sync
+- `isCurrent` — whether this is the checked-out branch
+- `isMerged` — whether the PR has been merged
+- `needsRebase` — whether the base branch is not an ancestor (non-linear history)
+- `pr` — PR metadata (omitted if no PR exists). `state` is `"OPEN"` or `"MERGED"`.
+
+---
+
+### Navigate the stack
+
+Move between branches without remembering branch names. These commands are fully non-interactive.
+
+```bash
+gh stack up          # Move up one branch (further from trunk)
+gh stack up 3        # Move up three branches
+gh stack down        # Move down one branch (closer to trunk)
+gh stack down 2      # Move down two branches
+gh stack top         # Jump to the top of the stack (furthest from trunk)
+gh stack bottom      # Jump to the bottom (first non-merged branch above trunk)
+```
+
+Navigation clamps to stack bounds. Merged branches are skipped when navigating from active branches.
+
+---
+
+### Check out a stack — `gh stack checkout`
+
+Check out a stack from a pull request number or branch name. **Always provide an argument** — running `gh stack checkout` without arguments triggers an interactive selection menu.
+
+```
+gh stack checkout <pr-number | branch>
+```
+
+```bash
+# By PR number (pulls from GitHub)
+gh stack checkout 42
+
+# By branch name (local only)
+gh stack checkout feature-auth
+```
+
+When a PR number is provided (e.g. `123`), the command fetches the stack on GitHub, pulls the branches, and sets up the stack locally. If the stack already exists locally and matches, it switches to the branch.
+
+> **⚠️ Agent warning:** If the local and remote stacks have different branch compositions, this command triggers an interactive conflict-resolution prompt that cannot be bypassed with a flag. To avoid this: run `gh stack unstack` first to remove the conflicting local stack, then retry `gh stack checkout <pr-number>`.
+
+When a branch name is provided, the command resolves it against locally tracked stacks only. This is always safe for non-interactive use.
+
+---
+
+### Remove a stack — `gh stack unstack`
+
+Tear down a stack so you can restructure it — remove a branch, reorder branches, rename branches, or make other large changes. After unstacking, use `gh stack init` to re-create the stack with the desired structure.
+
+```
+gh stack unstack [flags] [branch]
+```
+
+```bash
+# Tear down the stack (locally and on GitHub), then rebuild
+gh stack unstack
+gh stack init --base main --adopt branch-2 branch-1 branch-3 # reordered
+
+# Only remove local tracking (keep the stack on GitHub)
+gh stack unstack --local
+
+# Specify a branch to identify which stack to tear down
+gh stack unstack feature-auth
+```
+
+| Flag | Description |
+|------|-------------|
+| `--local` | Only delete the stack locally (keep it on GitHub) |
+
+| Argument | Description |
+|----------|-------------|
+| `[branch]` | A branch in the stack (defaults to the current branch) |
+
+---
+
+## Output conventions
+
+- **Status messages** go to **stderr** with emoji prefixes: `✓` (success), `✗` (error), `⚠` (warning), `ℹ` (info).
+- **Data output** (e.g., `view --json`) goes to **stdout**.
+- When piping output, use `2>/dev/null` to suppress status messages if only data output is needed.
+
+## Exit codes and error recovery
+
+| Code | Meaning | Agent action |
+|------|---------|-------------|
+| 0 | Success | Proceed normally |
+| 1 | Generic error | Read stderr for details; may indicate commit/push failure |
+| 2 | Not in a stack | Run `gh stack init` to create a stack first |
+| 3 | Rebase conflict | Parse stderr for conflicted file paths, resolve conflicts, run `gh stack rebase --continue` |
+| 4 | GitHub API failure | Check `gh auth status`, retry the command |
+| 5 | Invalid arguments | Fix the command invocation (check flags and arguments) |
+| 6 | Disambiguation required | A branch belongs to multiple stacks. Run `gh stack checkout <specific-branch>` to switch to a non-shared branch first |
+| 7 | Rebase already in progress | Run `gh stack rebase --continue` (after resolving conflicts) or `gh stack rebase --abort` to start over |
+| 8 | Stack is locked | Another `gh stack` process is writing the stack file. Wait and retry — the lock times out after 5 seconds |
+| 9 | Stacked PRs unavailable | The repository does not have stacked PRs enabled. `submit` will offer to create regular (unstacked) PRs in interactive mode |
+
+## Known limitations
+
+1. **Stacks are strictly linear.** Branching stacks (multiple children on a single parent) are not supported. Each branch has exactly one parent and at most one child. If you need parallel workstreams, use separate stacks.
+2. **Stack disambiguation cannot be bypassed.** If the current branch is the trunk of multiple stacks, commands error with code 6. Check out a non-shared branch first.
+3. **Multiple remotes require `--remote` or config.** If more than one remote is configured, pass `--remote <name>` or set `remote.pushDefault` in git config before running `push`, `sync`, or `rebase`.
+4. **Merging PRs:** Merging Stacked PRs from the CLI is not supported yet. Direct users to open the PR URL in a browser to merge PRs.
+5. **Remote stack checkout requires a PR number.** `checkout` with a branch name only works with locally tracked stacks. Use a PR number (e.g. `gh stack checkout 123`) to pull stacks from GitHub.
+6. **PR title and body are auto-generated.** There is no flag to set a custom PR title or body during `submit`. The title and body are generated from commit messages plus a footer. Use `gh pr edit` to modify PR title and body after creation.

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -1,0 +1,128 @@
+---
+allowed-tools: Bash
+description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping'
+license: MIT
+metadata:
+    github-path: skills/git-commit
+    github-ref: refs/heads/main
+    github-repo: https://github.com/github/awesome-copilot
+    github-tree-sha: 883a6a7466f55a9cd9f22cf1cce2d9333fc9b998
+name: git-commit
+---
+# Git Commit with Conventional Commits
+
+## Overview
+
+Create standardized, semantic git commits using the Conventional Commits specification. Analyze the actual diff to determine appropriate type, scope, and message.
+
+## Conventional Commit Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Commit Types
+
+| Type       | Purpose                        |
+| ---------- | ------------------------------ |
+| `feat`     | New feature                    |
+| `fix`      | Bug fix                        |
+| `docs`     | Documentation only             |
+| `style`    | Formatting/style (no logic)    |
+| `refactor` | Code refactor (no feature/fix) |
+| `perf`     | Performance improvement        |
+| `test`     | Add/update tests               |
+| `build`    | Build system/dependencies      |
+| `ci`       | CI/config changes              |
+| `chore`    | Maintenance/misc               |
+| `revert`   | Revert commit                  |
+
+## Breaking Changes
+
+```
+# Exclamation mark after type/scope
+feat!: remove deprecated endpoint
+
+# BREAKING CHANGE footer
+feat: allow config to extend other configs
+
+BREAKING CHANGE: `extends` key behavior changed
+```
+
+## Workflow
+
+### 1. Analyze Diff
+
+```bash
+# If files are staged, use staged diff
+git diff --staged
+
+# If nothing staged, use working tree diff
+git diff
+
+# Also check status
+git status --porcelain
+```
+
+### 2. Stage Files (if needed)
+
+If nothing is staged or you want to group changes differently:
+
+```bash
+# Stage specific files
+git add path/to/file1 path/to/file2
+
+# Stage by pattern
+git add *.test.*
+git add src/components/*
+
+# Interactive staging
+git add -p
+```
+
+**Never commit secrets** (.env, credentials.json, private keys).
+
+### 3. Generate Commit Message
+
+Analyze the diff to determine:
+
+- **Type**: What kind of change is this?
+- **Scope**: What area/module is affected?
+- **Description**: One-line summary of what changed (present tense, imperative mood, <72 chars)
+
+### 4. Execute Commit
+
+```bash
+# Single line
+git commit -m "<type>[scope]: <description>"
+
+# Multi-line with body/footer
+git commit -m "$(cat <<'EOF'
+<type>[scope]: <description>
+
+<optional body>
+
+<optional footer>
+EOF
+)"
+```
+
+## Best Practices
+
+- One logical change per commit
+- Present tense: "add" not "added"
+- Imperative mood: "fix bug" not "fixes bug"
+- Reference issues: `Closes #123`, `Refs #456`
+- Keep description under 72 characters
+
+## Git Safety Protocol
+
+- NEVER update git config
+- NEVER run destructive commands (--force, hard reset) without explicit request
+- NEVER skip hooks (--no-verify) unless user asks
+- NEVER force push to main/master
+- If commit fails due to hooks, fix and create NEW commit (don't amend)

--- a/.agents/skills/github-actions-docs/SKILL.md
+++ b/.agents/skills/github-actions-docs/SKILL.md
@@ -1,0 +1,102 @@
+---
+description: Use when users ask how to write, explain, customize, migrate, secure, or troubleshoot GitHub Actions workflows, workflow syntax, triggers, matrices, runners, reusable workflows, artifacts, caching, secrets, OIDC, deployments, custom actions, or Actions Runner Controller, especially when they need official GitHub documentation, exact links, or docs-grounded YAML guidance.
+metadata:
+    github-path: skills/github-actions-docs
+    github-ref: refs/heads/main
+    github-repo: https://github.com/xixu-me/skills
+    github-tree-sha: 518c85da555f91c346813aa5bb3cc62f9db8bfb3
+name: github-actions-docs
+---
+GitHub Actions questions are easy to answer from stale memory. Use this skill to ground answers in official GitHub documentation and return the closest authoritative page instead of generic CI/CD advice.
+
+## When to Use
+
+Use this skill when the request is about:
+
+- GitHub Actions concepts, terminology, or product boundaries
+- Workflow YAML, triggers, jobs, matrices, concurrency, variables, contexts, or expressions
+- GitHub-hosted runners, larger runners, self-hosted runners, or Actions Runner Controller
+- Artifacts, caches, reusable workflows, workflow templates, or custom actions
+- Secrets, `GITHUB_TOKEN`, OpenID Connect, artifact attestations, or secure workflow patterns
+- Environments, deployment protection rules, deployment history, or deployment examples
+- Migrating from Jenkins, CircleCI, GitLab CI/CD, Travis CI, Azure Pipelines, or other CI systems
+- Troubleshooting workflow behavior when the user needs documentation, syntax guidance, or official references
+
+Do not use this skill for:
+
+- A specific failing PR check, missing workflow log, or CI failure triage. Use `gh-fix-ci`.
+- General GitHub pull request, branch, or repository operations. Use `github`.
+- CodeQL-specific configuration or code scanning guidance. Use `codeql`.
+- Dependabot configuration, grouping, or dependency update strategy. Use `dependabot`.
+
+## Workflow
+
+### 1. Classify the request
+
+Decide which bucket the question belongs to before searching:
+
+- Getting started or tutorials
+- Workflow authoring and syntax
+- Runners and execution environment
+- Security and supply chain
+- Deployments and environments
+- Custom actions and publishing
+- Monitoring, logs, and troubleshooting
+- Migration
+
+If you need a quick starting point, load `references/topic-map.md` and jump to the closest section.
+
+### 2. Search official GitHub docs first
+
+- Treat `docs.github.com` as the source of truth.
+- Prefer pages under <https://docs.github.com/en/actions>.
+- Search with the user's exact terms plus a focused Actions phrase such as `workflow syntax`, `OIDC`, `reusable workflows`, or `self-hosted runners`.
+- When multiple pages are plausible, compare 2-3 candidate pages and pick the one that most directly answers the user's question.
+
+### 3. Open the best page before answering
+
+- Read the most relevant page, and the exact section when practical.
+- Use the topic map only to narrow the search space or surface likely starting pages.
+- If a page appears renamed, moved, or incomplete, say that explicitly and return the nearest authoritative pages instead of guessing.
+
+### 4. Answer with docs-grounded guidance
+
+- Start with a direct answer in plain language.
+- Include exact GitHub docs links, not just the docs homepage.
+- Only provide YAML or step-by-step examples when the user asks for them or when the docs page makes an example necessary.
+- Make any inference explicit. Good phrasing:
+  - `According to GitHub docs, ...`
+  - `Inference: this likely means ...`
+
+## Answer Shape
+
+Use a compact structure unless the user asks for depth:
+
+1. Direct answer
+2. Relevant docs
+3. Example YAML or steps, only if needed
+4. Explicit inference callout, only if you had to connect multiple docs pages
+
+Keep citations close to the claim they support.
+
+## Search and Routing Tips
+
+- For concept questions, prefer overview or concept pages before deep reference pages.
+- For syntax questions, prefer workflow syntax, events, contexts, variables, or expressions reference pages.
+- For security questions, prefer `Secure use`, `Secrets`, `GITHUB_TOKEN`, `OpenID Connect`, and artifact attestation docs.
+- For deployment questions, prefer environments and deployment protection docs before cloud-specific examples.
+- For migration questions, prefer the migration hub page first, then a platform-specific migration guide.
+- If the user asks for a beginner walkthrough, start with a tutorial or quickstart instead of a raw reference page.
+
+## Common Mistakes
+
+- Answering from memory without verifying the current docs
+- Linking the GitHub Actions docs landing page when a narrower page exists
+- Mixing up reusable workflows and composite actions
+- Suggesting long-lived cloud credentials when OIDC is the better documented path
+- Treating repo-specific CI debugging as a documentation question when it should be handed to `gh-fix-ci`
+- Letting adjacent domains absorb the request when `codeql` or `dependabot` is the sharper fit
+
+## Bundled Reference
+
+Read `references/topic-map.md` only as a compact index of likely doc entry points. It is intentionally incomplete and should never replace the live GitHub docs as the final authority.

--- a/.agents/skills/github-actions-docs/references/topic-map.md
+++ b/.agents/skills/github-actions-docs/references/topic-map.md
@@ -1,0 +1,90 @@
+# GitHub Actions Topic Map
+
+This reference is a compact routing aid derived from the source catalog. It is intentionally selective and deduplicated. Use it to find the right documentation neighborhood quickly, then verify against the live docs on `docs.github.com`.
+
+## Getting Started
+
+- [Understanding GitHub Actions](https://docs.github.com/en/actions/get-started/understand-github-actions)
+- [Quickstart for GitHub Actions](https://docs.github.com/en/actions/get-started/quickstart)
+- [Continuous integration](https://docs.github.com/en/actions/get-started/continuous-integration)
+- [Continuous deployment](https://docs.github.com/en/actions/get-started/continuous-deployment)
+- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+
+## Workflow Authoring
+
+- [Workflows](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflows)
+- [Variables](https://docs.github.com/en/actions/concepts/workflows-and-actions/variables)
+- [Contexts](https://docs.github.com/en/actions/concepts/workflows-and-actions/contexts)
+- [Expressions](https://docs.github.com/en/actions/concepts/workflows-and-actions/expressions)
+- [Using jobs in a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-jobs)
+- [Running variations of jobs in a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations)
+- [Passing information between jobs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs)
+- [Reuse workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
+- [Reusing workflow configurations](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations)
+
+## Runners and Execution
+
+- [GitHub-hosted runners](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners)
+- [Using GitHub-hosted runners](https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/use-github-hosted-runners)
+- [Choosing the runner for a job](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job)
+- [Running jobs in a container](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container)
+- [Self-hosted runners](https://docs.github.com/en/actions/concepts/runners/self-hosted-runners)
+- [Larger runners](https://docs.github.com/en/actions/concepts/runners/larger-runners)
+- [Actions Runner Controller](https://docs.github.com/en/actions/concepts/runners/actions-runner-controller)
+- [Get started with Actions Runner Controller](https://docs.github.com/en/actions/tutorials/use-actions-runner-controller/get-started)
+
+## Security and Supply Chain
+
+- [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- [Secrets](https://docs.github.com/en/actions/concepts/security/secrets)
+- [GITHUB_TOKEN](https://docs.github.com/en/actions/concepts/security/github_token)
+- [OpenID Connect](https://docs.github.com/en/actions/concepts/security/openid-connect)
+- [OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc)
+- [Artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations)
+- [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations)
+- [Using OpenID Connect with reusable workflows](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-with-reusable-workflows)
+- [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws)
+
+## Deployments and Environments
+
+- [Deployment environments](https://docs.github.com/en/actions/concepts/workflows-and-actions/deployment-environments)
+- [Deployments and environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)
+- [Deploying with GitHub Actions](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments)
+- [Managing environments for deployment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)
+- [Reviewing deployments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/review-deployments)
+- [Viewing deployment history](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/view-deployment-history)
+- [Deploying to Amazon Elastic Container Service](https://docs.github.com/en/actions/how-tos/deploy/deploy-to-third-party-platforms/amazon-elastic-container-service)
+- [Deploying Node.js to Azure App Service](https://docs.github.com/en/actions/how-tos/deploy/deploy-to-third-party-platforms/nodejs-to-azure-app-service)
+
+## Custom Actions and Publishing
+
+- [About custom actions](https://docs.github.com/en/actions/concepts/workflows-and-actions/custom-actions)
+- [Metadata syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax)
+- [Managing custom actions](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/manage-custom-actions)
+- [Creating a JavaScript action](https://docs.github.com/en/actions/tutorials/create-actions/create-a-javascript-action)
+- [Creating a composite action](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action)
+- [Creating a third party CLI action](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/create-a-cli-action)
+- [Publishing actions in GitHub Marketplace](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/publish-in-github-marketplace)
+- [Releasing and maintaining actions](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/release-and-maintain-actions)
+
+## Monitoring, Logs, and Troubleshooting
+
+- [Using the visualization graph](https://docs.github.com/en/actions/how-tos/monitor-workflows/use-the-visualization-graph)
+- [Viewing workflow run history](https://docs.github.com/en/actions/how-tos/monitor-workflows/view-workflow-run-history)
+- [Using workflow run logs](https://docs.github.com/en/actions/how-tos/monitor-workflows/use-workflow-run-logs)
+- [Viewing job condition expression logs](https://docs.github.com/en/actions/how-tos/monitor-workflows/view-job-condition-logs)
+- [Enabling debug logging](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging)
+- [Troubleshooting workflows](https://docs.github.com/en/actions/how-tos/troubleshoot-workflows)
+- [Viewing GitHub Actions metrics](https://docs.github.com/en/actions/how-tos/administer/view-metrics)
+
+## Migration and Tutorials
+
+- [Migrating to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions)
+- [Automating migration with GitHub Actions Importer](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/automated-migrations/use-github-actions-importer)
+- [Migrating from Jenkins to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/manual-migrations/migrate-from-jenkins)
+- [Migrating from CircleCI to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/manual-migrations/migrate-from-circleci)
+- [Migrating from GitLab CI/CD to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/manual-migrations/migrate-from-gitlab-cicd)
+- [Building and testing Node.js](https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs)
+- [Use GITHUB_TOKEN for authentication in workflows](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)
+- [Store and share data with workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data)

--- a/.agents/skills/github-issues/SKILL.md
+++ b/.agents/skills/github-issues/SKILL.md
@@ -1,0 +1,205 @@
+---
+description: Create, update, and manage GitHub issues using MCP tools. Use this skill when users want to create bug reports, feature requests, or task issues, update existing issues, add labels/assignees/milestones, set issue fields (dates, priority, custom fields), set issue types, manage issue workflows, link issues, add dependencies, or track blocked-by/blocking relationships. Triggers on requests like "create an issue", "file a bug", "request a feature", "update issue X", "set the priority", "set the start date", "link issues", "add dependency", "blocked by", "blocking", or any GitHub issue management task.
+metadata:
+    github-path: skills/github-issues
+    github-ref: refs/heads/main
+    github-repo: https://github.com/github/awesome-copilot
+    github-tree-sha: 44219c182a1435252a1751313b99fb0a79882bb5
+name: github-issues
+---
+# GitHub Issues
+
+Manage GitHub issues using the `@modelcontextprotocol/server-github` MCP server.
+
+## Available Tools
+
+### MCP Tools (read operations)
+
+| Tool | Purpose |
+|------|---------|
+| `mcp__github__issue_read` | Read issue details, sub-issues, comments, labels (methods: get, get_comments, get_sub_issues, get_labels) |
+| `mcp__github__list_issues` | List and filter repository issues by state, labels, date |
+| `mcp__github__search_issues` | Search issues across repos using GitHub search syntax |
+| `mcp__github__projects_list` | List projects, project fields, project items, status updates |
+| `mcp__github__projects_get` | Get details of a project, field, item, or status update |
+| `mcp__github__projects_write` | Add/update/delete project items, create status updates |
+
+### CLI / REST API (write operations)
+
+The MCP server does not currently support creating, updating, or commenting on issues. Use `gh api` for these operations.
+
+| Operation | Command |
+|-----------|---------|
+| Create issue | `gh api repos/{owner}/{repo}/issues -X POST -f title=... -f body=...` |
+| Update issue | `gh api repos/{owner}/{repo}/issues/{number} -X PATCH -f title=... -f state=...` |
+| Add comment | `gh api repos/{owner}/{repo}/issues/{number}/comments -X POST -f body=...` |
+| Close issue | `gh api repos/{owner}/{repo}/issues/{number} -X PATCH -f state=closed` |
+| Set issue type | Include `-f type=Bug` in the create call (REST API only, not supported by `gh issue create` CLI) |
+
+**Note:** `gh issue create` works for basic issue creation but does **not** support the `--type` flag. Use `gh api` when you need to set issue types.
+
+## Workflow
+
+1. **Determine action**: Create, update, or query?
+2. **Gather context**: Get repo info, existing labels, milestones if needed
+3. **Structure content**: Use appropriate template from [references/templates.md](references/templates.md)
+4. **Execute**: Use MCP tools for reads, `gh api` for writes
+5. **Confirm**: Report the issue URL to user
+
+## Creating Issues
+
+Use `gh api` to create issues. This supports all parameters including issue types.
+
+```bash
+gh api repos/{owner}/{repo}/issues \
+  -X POST \
+  -f title="Issue title" \
+  -f body="Issue body in markdown" \
+  -f type="Bug" \
+  --jq '{number, html_url}'
+```
+
+### Optional Parameters
+
+Add any of these flags to the `gh api` call:
+
+```
+-f type="Bug"                    # Issue type (Bug, Feature, Task, Epic, etc.)
+-f labels[]="bug"                # Labels (repeat for multiple)
+-f assignees[]="username"        # Assignees (repeat for multiple)
+-f milestone=1                   # Milestone number
+```
+
+**Issue types** are organization-level metadata. To discover available types, use:
+```bash
+gh api graphql -f query='{ organization(login: "ORG") { issueTypes(first: 10) { nodes { name } } } }' --jq '.data.organization.issueTypes.nodes[].name'
+```
+
+**Prefer issue types over labels for categorization.** When issue types are available (e.g., Bug, Feature, Task), use the `type` parameter instead of applying equivalent labels like `bug` or `enhancement`. Issue types are the canonical way to categorize issues on GitHub. Only fall back to labels when the org has no issue types configured.
+
+### Title Guidelines
+
+- Be specific and actionable
+- Keep under 72 characters
+- When issue types are set, don't add redundant prefixes like `[Bug]`
+- Examples:
+  - `Login fails with SSO enabled` (with type=Bug)
+  - `Add dark mode support` (with type=Feature)
+  - `Add unit tests for auth module` (with type=Task)
+
+### Body Structure
+
+Always use the templates in [references/templates.md](references/templates.md). Choose based on issue type:
+
+| User Request | Template |
+|--------------|----------|
+| Bug, error, broken, not working | Bug Report |
+| Feature, enhancement, add, new | Feature Request |
+| Task, chore, refactor, update | Task |
+
+## Updating Issues
+
+Use `gh api` with PATCH:
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number} \
+  -X PATCH \
+  -f state=closed \
+  -f title="Updated title" \
+  --jq '{number, html_url}'
+```
+
+Only include fields you want to change. Available fields: `title`, `body`, `state` (open/closed), `labels`, `assignees`, `milestone`.
+
+## Examples
+
+### Example 1: Bug Report
+
+**User**: "Create a bug issue - the login page crashes when using SSO"
+
+**Action**: 
+```bash
+gh api repos/github/awesome-copilot/issues \
+  -X POST \
+  -f title="Login page crashes when using SSO" \
+  -f type="Bug" \
+  -f body="## Description
+The login page crashes when users attempt to authenticate using SSO.
+
+## Steps to Reproduce
+1. Navigate to login page
+2. Click 'Sign in with SSO'
+3. Page crashes
+
+## Expected Behavior
+SSO authentication should complete and redirect to dashboard.
+
+## Actual Behavior
+Page becomes unresponsive and displays error." \
+  --jq '{number, html_url}'
+```
+
+### Example 2: Feature Request
+
+**User**: "Create a feature request for dark mode with high priority"
+
+**Action**:
+```bash
+gh api repos/github/awesome-copilot/issues \
+  -X POST \
+  -f title="Add dark mode support" \
+  -f type="Feature" \
+  -f labels[]="high-priority" \
+  -f body="## Summary
+Add dark mode theme option for improved user experience and accessibility.
+
+## Motivation
+- Reduces eye strain in low-light environments
+- Increasingly expected by users
+
+## Proposed Solution
+Implement theme toggle with system preference detection.
+
+## Acceptance Criteria
+- [ ] Toggle switch in settings
+- [ ] Persists user preference
+- [ ] Respects system preference by default" \
+  --jq '{number, html_url}'
+```
+
+## Common Labels
+
+Use these standard labels when applicable:
+
+| Label | Use For |
+|-------|---------|
+| `bug` | Something isn't working |
+| `enhancement` | New feature or improvement |
+| `documentation` | Documentation updates |
+| `good first issue` | Good for newcomers |
+| `help wanted` | Extra attention needed |
+| `question` | Further information requested |
+| `wontfix` | Will not be addressed |
+| `duplicate` | Already exists |
+| `high-priority` | Urgent issues |
+
+## Tips
+
+- Always confirm the repository context before creating issues
+- Ask for missing critical information rather than guessing
+- Link related issues when known: `Related to #123`
+- For updates, fetch current issue first to preserve unchanged fields
+
+## Extended Capabilities
+
+The following features require REST or GraphQL APIs beyond the basic MCP tools. Each is documented in its own reference file so the agent only loads the knowledge it needs.
+
+| Capability | When to use | Reference |
+|------------|-------------|-----------|
+| Advanced search | Complex queries with boolean logic, date ranges, cross-repo search, issue field filters (`field.name:value`) | [references/search.md](references/search.md) |
+| Sub-issues & parent issues | Breaking work into hierarchical tasks | [references/sub-issues.md](references/sub-issues.md) |
+| Issue dependencies | Tracking blocked-by / blocking relationships | [references/dependencies.md](references/dependencies.md) |
+| Issue types (advanced) | GraphQL operations beyond MCP `list_issue_types` / `type` param | [references/issue-types.md](references/issue-types.md) |
+| Projects V2 | Project boards, progress reports, field management | [references/projects.md](references/projects.md) |
+| Issue fields | Custom metadata: dates, priority, text, numbers (private preview) | [references/issue-fields.md](references/issue-fields.md) |
+| Images in issues | Embedding images in issue bodies and comments via CLI | [references/images.md](references/images.md) |

--- a/.agents/skills/github-issues/references/dependencies.md
+++ b/.agents/skills/github-issues/references/dependencies.md
@@ -1,0 +1,71 @@
+# Issue Dependencies (Blocked By / Blocking)
+
+Dependencies let you mark that an issue is blocked by another issue. This creates a formal dependency relationship visible in the UI and trackable via API. No MCP tools exist for dependencies; use REST or GraphQL directly.
+
+## Using REST API
+
+**List issues blocking this issue:**
+```
+GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by
+```
+
+**Add a blocking dependency:**
+```
+POST /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by
+Body: { "issue_id": 12345 }
+```
+
+The `issue_id` is the numeric issue **ID** (not the issue number).
+
+**Remove a blocking dependency:**
+```
+DELETE /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by/{issue_id}
+```
+
+## Using GraphQL
+
+**Read dependencies:**
+```graphql
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      blockedBy(first: 10) { nodes { number title state } }
+      blocking(first: 10) { nodes { number title state } }
+      issueDependenciesSummary { blockedBy blocking totalBlockedBy totalBlocking }
+    }
+  }
+}
+```
+
+**Add a dependency:**
+```graphql
+mutation {
+  addBlockedBy(input: {
+    issueId: "BLOCKED_ISSUE_NODE_ID"
+    blockingIssueId: "BLOCKING_ISSUE_NODE_ID"
+  }) {
+    blockingIssue { number title }
+  }
+}
+```
+
+**Remove a dependency:**
+```graphql
+mutation {
+  removeBlockedBy(input: {
+    issueId: "BLOCKED_ISSUE_NODE_ID"
+    blockingIssueId: "BLOCKING_ISSUE_NODE_ID"
+  }) {
+    blockingIssue { number title }
+  }
+}
+```
+
+## Tracked issues (read-only)
+
+Task-list tracking relationships are available via GraphQL as read-only fields:
+
+- `trackedIssues(first: N)` - issues tracked in this issue's task list
+- `trackedInIssues(first: N)` - issues whose task lists reference this issue
+
+These are set automatically when issues are referenced in task lists (`- [ ] #123`). There are no mutations to manage them.

--- a/.agents/skills/github-issues/references/images.md
+++ b/.agents/skills/github-issues/references/images.md
@@ -1,0 +1,116 @@
+# Images in Issues and Comments
+
+How to embed images in GitHub issue bodies and comments programmatically via the CLI.
+
+## Methods (ranked by reliability)
+
+### 1. GitHub Contents API (recommended for private repos)
+
+Push image files to a branch in the same repo, then reference them with a URL that works for authenticated viewers.
+
+**Step 1: Create a branch**
+
+```bash
+# Get the SHA of the default branch
+SHA=$(gh api repos/{owner}/{repo}/git/ref/heads/main --jq '.object.sha')
+
+# Create a new branch
+gh api repos/{owner}/{repo}/git/refs -X POST \
+  -f ref="refs/heads/{username}/images" \
+  -f sha="$SHA"
+```
+
+**Step 2: Upload images via Contents API**
+
+```bash
+# Base64-encode the image and upload
+BASE64=$(base64 -i /path/to/image.png)
+
+gh api repos/{owner}/{repo}/contents/docs/images/my-image.png \
+  -X PUT \
+  -f message="Add image" \
+  -f content="$BASE64" \
+  -f branch="{username}/images" \
+  --jq '.content.path'
+```
+
+Repeat for each image. The Contents API creates a commit per file.
+
+**Step 3: Reference in markdown**
+
+```markdown
+![Description](https://github.com/{owner}/{repo}/raw/{username}/images/docs/images/my-image.png)
+```
+
+> **Important:** Use `github.com/{owner}/{repo}/raw/{branch}/{path}` format, NOT `raw.githubusercontent.com`. The `raw.githubusercontent.com` URLs return 404 for private repos. The `github.com/.../raw/...` format works because the browser sends auth cookies when the viewer is logged in and has repo access.
+
+**Pros:** Works for any repo the viewer has access to, images live in version control, no expiration.
+**Cons:** Creates commits, viewers must be authenticated, images won't render in email notifications or for users without repo access.
+
+### 2. Gist hosting (public images only)
+
+Upload images as files in a gist. Only works for images you're comfortable making public.
+
+```bash
+# Create a gist with a placeholder file
+gh gist create --public -f description.md <<< "Image hosting gist"
+
+# Note: gh gist edit does NOT support binary files.
+# You must use the API to add binary content to gists.
+```
+
+> **Limitation:** Gists don't support binary file uploads via the CLI. You'd need to base64-encode and store as text, which won't render as images. Not recommended.
+
+### 3. Browser upload (most reliable rendering)
+
+The most reliable way to get permanent image URLs is through the GitHub web UI:
+
+1. Open the issue/comment in a browser
+2. Drag-drop or paste the image into the comment editor
+3. GitHub generates a permanent `https://github.com/user-attachments/assets/{UUID}` URL
+4. These URLs work for anyone, even without repo access, and render in email notifications
+
+> **Why the API can't do this:** GitHub's `upload/policies/assets` endpoint requires a browser session (CSRF token + cookies). It returns an HTML error page when called with API tokens. There is no public API for generating `user-attachments` URLs.
+
+## Taking screenshots programmatically
+
+Use `puppeteer-core` with local Chrome to screenshot HTML mockups:
+
+```javascript
+const puppeteer = require('puppeteer-core');
+
+const browser = await puppeteer.launch({
+  executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  defaultViewport: { width: 900, height: 600, deviceScaleFactor: 2 }
+});
+
+const page = await browser.newPage();
+await page.setContent(htmlString);
+
+// Screenshot specific elements
+const elements = await page.$$('.section');
+for (let i = 0; i < elements.length; i++) {
+  await elements[i].screenshot({ path: `mockup-${i + 1}.png` });
+}
+
+await browser.close();
+```
+
+> **Note:** MCP Playwright may not connect to localhost due to network isolation. Use puppeteer-core with a local Chrome installation instead.
+
+## Quick reference
+
+| Method | Private repos | Permanent | No auth needed | API-only |
+|--------|:---:|:---:|:---:|:---:|
+| Contents API + `github.com/raw/` | ✅ | ✅ | ❌ | ✅ |
+| Browser drag-drop (`user-attachments`) | ✅ | ✅ | ✅ | ❌ |
+| `raw.githubusercontent.com` | ❌ (404) | ✅ | ❌ | ✅ |
+| Gist | Public only | ✅ | ✅ | ❌ (no binary) |
+
+## Common pitfalls
+
+- **`raw.githubusercontent.com` returns 404 for private repos** even with a valid token in the URL. GitHub's CDN does not pass auth headers through.
+- **API download URLs are temporary.** URLs returned by `gh api repos/.../contents/...` with `download_url` include a token that expires.
+- **`upload/policies/assets` requires a browser session.** Do not attempt to call this endpoint from the CLI.
+- **Base64 encoding for large files** can hit API payload limits. The Contents API has a ~100MB file size limit but practical limits are lower for base64-encoded payloads.
+- **Email notifications** will not render images that require authentication. If email readability matters, use the browser upload method.

--- a/.agents/skills/github-issues/references/issue-fields.md
+++ b/.agents/skills/github-issues/references/issue-fields.md
@@ -1,0 +1,191 @@
+# Issue Fields (GraphQL, Private Preview)
+
+> **Private preview:** Issue fields are currently in private preview. Request access at https://github.com/orgs/community/discussions/175366
+
+Issue fields are custom metadata (dates, text, numbers, single-select) defined at the organization level and set per-issue. They are separate from labels, milestones, and assignees. Common examples: Start Date, Target Date, Priority, Impact, Effort.
+
+**Important:** All issue field queries and mutations require the `GraphQL-Features: issue_fields` HTTP header. Without it, the fields are not visible in the schema.
+
+**Prefer issue fields over project fields.** When you need to set metadata like dates, priority, or status on an issue, use issue fields (which live on the issue itself) rather than project fields (which live on a project item). Issue fields travel with the issue across projects and views, while project fields are scoped to a single project. Only use project fields when issue fields are not available or when the field is project-specific (e.g., sprint iterations).
+
+## Discovering available fields
+
+Fields are defined at the org level. List them before trying to set values:
+
+```graphql
+# Header: GraphQL-Features: issue_fields
+{
+  organization(login: "OWNER") {
+    issueFields(first: 30) {
+      nodes {
+        __typename
+        ... on IssueFieldDate { id name }
+        ... on IssueFieldText { id name }
+        ... on IssueFieldNumber { id name }
+        ... on IssueFieldSingleSelect { id name options { id name color } }
+      }
+    }
+  }
+}
+```
+
+Field types: `IssueFieldDate`, `IssueFieldText`, `IssueFieldNumber`, `IssueFieldSingleSelect`.
+
+For single-select fields, you need the option `id` (not the name) to set values.
+
+## Reading field values on an issue
+
+```graphql
+# Header: GraphQL-Features: issue_fields
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      issueFieldValues(first: 20) {
+        nodes {
+          __typename
+          ... on IssueFieldDateValue {
+            value
+            field { ... on IssueFieldDate { id name } }
+          }
+          ... on IssueFieldTextValue {
+            value
+            field { ... on IssueFieldText { id name } }
+          }
+          ... on IssueFieldNumberValue {
+            value
+            field { ... on IssueFieldNumber { id name } }
+          }
+          ... on IssueFieldSingleSelectValue {
+            name
+            color
+            field { ... on IssueFieldSingleSelect { id name } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Setting field values
+
+Use `setIssueFieldValue` to set one or more fields at once. You need the issue's node ID and the field IDs from the discovery query above.
+
+```graphql
+# Header: GraphQL-Features: issue_fields
+mutation {
+  setIssueFieldValue(input: {
+    issueId: "ISSUE_NODE_ID"
+    issueFields: [
+      { fieldId: "IFD_xxx", dateValue: "2026-04-15" }
+      { fieldId: "IFT_xxx", textValue: "some text" }
+      { fieldId: "IFN_xxx", numberValue: 3.0 }
+      { fieldId: "IFSS_xxx", singleSelectOptionId: "OPTION_ID" }
+    ]
+  }) {
+    issue { id title }
+  }
+}
+```
+
+Each entry in `issueFields` takes a `fieldId` plus exactly one value parameter:
+
+| Field type | Value parameter | Format |
+|-----------|----------------|--------|
+| Date | `dateValue` | ISO 8601 date string, e.g. `"2026-04-15"` |
+| Text | `textValue` | String |
+| Number | `numberValue` | Float |
+| Single select | `singleSelectOptionId` | ID from the field's `options` list |
+
+To clear a field value, set `delete: true` instead of a value parameter.
+
+## Workflow for setting fields
+
+1. **Discover fields** - query the org's `issueFields` to get field IDs and option IDs
+2. **Get the issue node ID** - from `repository.issue.id`
+3. **Set values** - call `setIssueFieldValue` with the issue node ID and field entries
+4. **Batch when possible** - multiple fields can be set in a single mutation call
+
+## Example: Set dates and priority on an issue
+
+```bash
+gh api graphql \
+  -H "GraphQL-Features: issue_fields" \
+  -f query='
+mutation {
+  setIssueFieldValue(input: {
+    issueId: "I_kwDOxxx"
+    issueFields: [
+      { fieldId: "IFD_startDate", dateValue: "2026-04-01" }
+      { fieldId: "IFD_targetDate", dateValue: "2026-04-30" }
+      { fieldId: "IFSS_priority", singleSelectOptionId: "OPTION_P1" }
+    ]
+  }) {
+    issue { id title }
+  }
+}'
+```
+
+## Searching by field values
+
+### GraphQL bulk query (recommended)
+
+The most reliable way to find issues by field value is to fetch issues via GraphQL and filter by `issueFieldValues`. The search qualifier syntax (`field.name:value`) is not yet reliable across all environments.
+
+```bash
+# Find all open P1 issues in a repo
+gh api graphql -H "GraphQL-Features: issue_fields" -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issues(first: 100, states: OPEN) {
+      nodes {
+        number
+        title
+        updatedAt
+        assignees(first: 3) { nodes { login } }
+        issueFieldValues(first: 10) {
+          nodes {
+            __typename
+            ... on IssueFieldSingleSelectValue {
+              name
+              field { ... on IssueFieldSingleSelect { name } }
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '
+  [.data.repository.issues.nodes[] |
+    select(.issueFieldValues.nodes[] |
+      select(.field.name == "Priority" and .name == "P1")
+    ) |
+    {number, title, updatedAt, assignees: [.assignees.nodes[].login]}
+  ]'
+```
+
+**Schema notes for `IssueFieldSingleSelectValue`:**
+- The selected option's display text is in `.name` (not `.value`)
+- Also available: `.color`, `.description`, `.id`
+- The parent field reference is in `.field` (use inline fragment to get the field name)
+
+### Search qualifier syntax (experimental)
+
+Issue fields may also be searchable using dot notation in search queries. This requires `advanced_search=true` on REST or `ISSUE_ADVANCED` search type on GraphQL, but results are inconsistent and may return 0 results even when matching issues exist.
+
+```
+field.priority:P0                  # Single-select equals value
+field.target-date:>=2026-04-01     # Date comparison
+has:field.priority                 # Has any value set
+no:field.priority                  # Has no value set
+```
+
+Field names use the **slug** (lowercase, hyphens for spaces). For example, "Target Date" becomes `target-date`.
+
+```bash
+# REST API (may not return results in all environments)
+gh api "search/issues?q=repo:owner/repo+field.priority:P0+is:open&advanced_search=true" \
+  --jq '.items[] | "#\(.number): \(.title)"'
+```
+
+> **Warning:** The colon notation (`field:Priority:P1`) is silently ignored. If using search qualifiers, always use dot notation (`field.priority:P1`). However, the GraphQL bulk query approach above is more reliable. See [search.md](search.md) for the full search guide.

--- a/.agents/skills/github-issues/references/issue-types.md
+++ b/.agents/skills/github-issues/references/issue-types.md
@@ -1,0 +1,72 @@
+# Issue Types (Advanced GraphQL)
+
+Issue types (Bug, Feature, Task, Epic, etc.) are defined at the **organization** level and inherited by repositories. They categorize issues beyond labels.
+
+For basic usage, the MCP tools handle issue types natively. Call `mcp__github__list_issue_types` to discover types, and pass `type: "Bug"` to `mcp__github__create_issue` or `mcp__github__update_issue`. This reference covers advanced GraphQL operations.
+
+## GraphQL Feature Header
+
+All GraphQL issue type operations require the `GraphQL-Features: issue_types` HTTP header.
+
+## List types (org or repo level)
+
+```graphql
+# Header: GraphQL-Features: issue_types
+{
+  organization(login: "OWNER") {
+    issueTypes(first: 20) {
+      nodes { id name color description isEnabled }
+    }
+  }
+}
+```
+
+Types can also be listed per-repo via `repository.issueTypes` or looked up by name via `repository.issueType(name: "Bug")`.
+
+## Read an issue's type
+
+```graphql
+# Header: GraphQL-Features: issue_types
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      issueType { id name color }
+    }
+  }
+}
+```
+
+## Set type on an existing issue
+
+```graphql
+# Header: GraphQL-Features: issue_types
+mutation {
+  updateIssueIssueType(input: {
+    issueId: "ISSUE_NODE_ID"
+    issueTypeId: "IT_xxx"
+  }) {
+    issue { id issueType { name } }
+  }
+}
+```
+
+## Create issue with type
+
+```graphql
+# Header: GraphQL-Features: issue_types
+mutation {
+  createIssue(input: {
+    repositoryId: "REPO_NODE_ID"
+    title: "Fix login bug"
+    issueTypeId: "IT_xxx"
+  }) {
+    issue { id number issueType { name } }
+  }
+}
+```
+
+To clear the type, set `issueTypeId` to `null`.
+
+## Available colors
+
+`GRAY`, `BLUE`, `GREEN`, `YELLOW`, `ORANGE`, `RED`, `PINK`, `PURPLE`

--- a/.agents/skills/github-issues/references/projects.md
+++ b/.agents/skills/github-issues/references/projects.md
@@ -1,0 +1,273 @@
+# Projects V2
+
+GitHub Projects V2 is managed via GraphQL. The MCP server provides three tools that wrap the GraphQL API, so you typically don't need raw GraphQL.
+
+## Using MCP tools (preferred)
+
+**List projects:**
+Call `mcp__github__projects_list` with `method: "list_projects"`, `owner`, and `owner_type` ("user" or "organization").
+
+**List project fields:**
+Call `mcp__github__projects_list` with `method: "list_project_fields"` and `project_number`.
+
+**List project items:**
+Call `mcp__github__projects_list` with `method: "list_project_items"` and `project_number`.
+
+**Add an issue/PR to a project:**
+Call `mcp__github__projects_write` with `method: "add_project_item"`, `project_id` (node ID), and `content_id` (issue/PR node ID).
+
+**Update a project item field value:**
+Call `mcp__github__projects_write` with `method: "update_project_item"`, `project_id`, `item_id`, `field_id`, and `value` (object with one of: `text`, `number`, `date`, `singleSelectOptionId`, `iterationId`).
+
+**Delete a project item:**
+Call `mcp__github__projects_write` with `method: "delete_project_item"`, `project_id`, and `item_id`.
+
+## Workflow for project operations
+
+1. **Find the project** — see [Finding a project by name](#finding-a-project-by-name) below
+2. **Discover fields** - use `projects_list` with `list_project_fields` to get field IDs and option IDs
+3. **Find items** - use `projects_list` with `list_project_items` to get item IDs
+4. **Mutate** - use `projects_write` to add, update, or delete items
+
+## Finding a project by name
+
+> **⚠️ Known issue:** `projectsV2(query: "…")` does keyword search, not exact name match, and returns results sorted by recency. Common words like "issue" or "bug" return hundreds of false positives. The actual project may be buried dozens of pages deep.
+
+Use this priority order:
+
+### 1. Direct lookup (if you know the number)
+```bash
+gh api graphql -f query='{
+  organization(login: "ORG") {
+    projectV2(number: 42) { id title }
+  }
+}' --jq '.data.organization.projectV2'
+```
+
+### 2. Reverse lookup from a known issue (most reliable)
+If the user mentions an issue, epic, or milestone that's in the project, query that issue's `projectItems` to discover the project:
+
+```bash
+gh api graphql -f query='{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project { number title id }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.issue.projectItems.nodes[] | {number: .project.number, title: .project.title, id: .project.id}'
+```
+
+This is the most reliable approach for large orgs where name search fails.
+
+### 3. GraphQL name search with client-side filtering (fallback)
+Query a large page and filter client-side for an exact title match:
+
+```bash
+gh api graphql -f query='{
+  organization(login: "ORG") {
+    projectsV2(first: 100, query: "search term") {
+      nodes { number title id }
+    }
+  }
+}' --jq '.data.organization.projectsV2.nodes[] | select(.title | test("(?i)^exact name$"))'
+```
+
+If this returns nothing, paginate with `after` cursor or broaden the regex. Results are sorted by recency so older projects require pagination.
+
+### 4. MCP tool (small orgs only)
+Call `mcp__github__projects_list` with `method: "list_projects"`. This works well for orgs with <50 projects but has no name filter, so you must scan all results.
+
+## Project discovery for progress reports
+
+When a user asks for a progress update on a project (e.g., "Give me a progress update for Project X"), follow this workflow:
+
+1. **Find the project** — use the [finding a project](#finding-a-project-by-name) strategies above. Ask the user for a known issue number if name search fails.
+
+2. **Discover fields** - call `projects_list` with `list_project_fields` to find the Status field (its options tell you the workflow stages) and any Iteration field (to scope to the current sprint).
+
+3. **Get all items** - call `projects_list` with `list_project_items`. For large projects (100+ items), paginate through all pages. Each item includes its field values (status, iteration, assignees).
+
+4. **Build the report** - group items by Status field value and count them. For iteration-based projects, filter to the current iteration first. Present a breakdown like:
+
+   ```
+   Project: Issue Fields (Iteration 42, Mar 2-8)
+   15 actionable items:
+     🎉 Done:        4 (27%)
+     In Review:      3
+     In Progress:    3
+     Ready:          2
+     Blocked:        2
+   ```
+
+5. **Add context** - if items have sub-issues, include `subIssuesSummary` counts. If items have dependencies, note blocked items and what blocks them.
+
+## OAuth Scope Requirements
+
+| Operation | Required scope |
+|-----------|---------------|
+| Read projects, fields, items | `read:project` |
+| Add/update/delete items, change field values | `project` |
+
+**Common pitfall:** The default `gh auth` token often only has `read:project`. Mutations will fail with `INSUFFICIENT_SCOPES`. To add the write scope:
+
+```bash
+gh auth refresh -h github.com -s project
+```
+
+This triggers a browser-based OAuth flow. You must complete it before mutations will work.
+
+## Finding an Issue's Project Item ID
+
+When you know the issue but need its project item ID (e.g., to update its Status), query from the issue side:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      projectItems(first: 5) {
+        nodes {
+          id
+          project { title number }
+          fieldValues(first: 10) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.issue.projectItems.nodes'
+```
+
+This returns the item ID, project info, and current field values in one query.
+
+## Using GraphQL via gh api (recommended)
+
+Use `gh api graphql` to run GraphQL queries and mutations. This is more reliable than MCP tools for write operations.
+
+**Find a project and its Status field options:**
+```bash
+gh api graphql -f query='
+{
+  organization(login: "ORG") {
+    projectV2(number: 5) {
+      id
+      title
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }
+}' --jq '.data.organization.projectV2'
+```
+
+**List all fields (including iterations):**
+```bash
+gh api graphql -f query='
+{
+  node(id: "PROJECT_ID") {
+    ... on ProjectV2 {
+      fields(first: 20) {
+        nodes {
+          ... on ProjectV2Field { id name }
+          ... on ProjectV2SingleSelectField { id name options { id name } }
+          ... on ProjectV2IterationField { id name configuration { iterations { id startDate } } }
+        }
+      }
+    }
+  }
+}' --jq '.data.node.fields.nodes'
+```
+
+**Update a field value (e.g., set Status to "In Progress"):**
+```bash
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PROJECT_ID"
+    itemId: "ITEM_ID"
+    fieldId: "FIELD_ID"
+    value: { singleSelectOptionId: "OPTION_ID" }
+  }) {
+    projectV2Item { id }
+  }
+}'
+```
+
+Value accepts one of: `text`, `number`, `date`, `singleSelectOptionId`, `iterationId`.
+
+**Add an item:**
+```bash
+gh api graphql -f query='
+mutation {
+  addProjectV2ItemById(input: {
+    projectId: "PROJECT_ID"
+    contentId: "ISSUE_OR_PR_NODE_ID"
+  }) {
+    item { id }
+  }
+}'
+```
+
+**Delete an item:**
+```bash
+gh api graphql -f query='
+mutation {
+  deleteProjectV2Item(input: {
+    projectId: "PROJECT_ID"
+    itemId: "ITEM_ID"
+  }) {
+    deletedItemId
+  }
+}'
+```
+
+## End-to-End Example: Set Issue Status to "In Progress"
+
+```bash
+# 1. Get the issue's project item ID, project ID, and current status
+gh api graphql -f query='{
+  repository(owner: "github", name: "planning-tracking") {
+    issue(number: 2574) {
+      projectItems(first: 1) {
+        nodes { id project { id title } }
+      }
+    }
+  }
+}' --jq '.data.repository.issue.projectItems.nodes[0]'
+
+# 2. Get the Status field ID and "In Progress" option ID
+gh api graphql -f query='{
+  node(id: "PROJECT_ID") {
+    ... on ProjectV2 {
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField { id options { id name } }
+      }
+    }
+  }
+}' --jq '.data.node.field'
+
+# 3. Update the status
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PROJECT_ID"
+    itemId: "ITEM_ID"
+    fieldId: "FIELD_ID"
+    value: { singleSelectOptionId: "IN_PROGRESS_OPTION_ID" }
+  }) { projectV2Item { id } }
+}'
+```
+```

--- a/.agents/skills/github-issues/references/search.md
+++ b/.agents/skills/github-issues/references/search.md
@@ -1,0 +1,231 @@
+# Advanced Issue Search
+
+The `search_issues` MCP tool uses GitHub's issue search query format for cross-repo searches, supporting implicit-AND queries, date ranges, and metadata filters (but not explicit OR/NOT operators).
+
+## When to Use Search vs List vs Advanced Search
+
+There are three ways to find issues, each with different capabilities:
+
+| Capability | `list_issues` (MCP) | `search_issues` (MCP) | Advanced search (`gh api`) |
+|-----------|---------------------|----------------------|---------------------------|
+| **Scope** | Single repo only | Cross-repo, cross-org | Cross-repo, cross-org |
+| **Issue field filters** (`field.priority:P0`) | No | No | **Yes** (dot notation) |
+| **Issue type filter** (`type:Bug`) | No | Yes | Yes |
+| **Boolean logic** (AND/OR/NOT, nesting) | No | Yes (implicit AND only) | **Yes** (explicit AND/OR/NOT) |
+| **Label/state/date filters** | Yes | Yes | Yes |
+| **Assignee/author/mentions** | No | Yes | Yes |
+| **Negation** (`-label:x`, `no:label`) | No | Yes | Yes |
+| **Text search** (title/body/comments) | No | Yes | Yes |
+| **`since` filter** | Yes | No | No |
+| **Result limit** | No cap (paginate all) | 1,000 max | 1,000 max |
+| **How to call** | MCP tool directly | MCP tool directly | `gh api` with `advanced_search=true` |
+
+**Decision guide:**
+- **Single repo, simple filters (state, labels, recent updates):** use `list_issues`
+- **Cross-repo, text search, author/assignee, issue types:** use `search_issues`
+- **Issue field values (Priority, dates, custom fields) or complex boolean logic:** use `gh api` with `advanced_search=true`
+
+## Query Syntax
+
+The `query` parameter is a string of search terms and qualifiers. A space between terms is implicit AND.
+
+### Scoping
+
+```
+repo:owner/repo       # Single repo (auto-added if you pass owner+repo params)
+org:github            # All repos in an org
+user:octocat          # All repos owned by user
+in:title              # Search only in title
+in:body               # Search only in body
+in:comments           # Search only in comments
+```
+
+### State & Close Reason
+
+```
+is:open               # Open issues (auto-added: is:issue)
+is:closed             # Closed issues
+reason:completed      # Closed as completed
+reason:"not planned"  # Closed as not planned
+```
+
+### People
+
+```
+author:username       # Created by
+assignee:username     # Assigned to
+mentions:username     # Mentions user
+commenter:username    # Has comment from
+involves:username     # Author OR assignee OR mentioned OR commenter
+author:@me            # Current authenticated user
+team:org/team         # Team mentioned
+```
+
+### Labels, Milestones, Projects, Types
+
+```
+label:"bug"                 # Has label (quote multi-word labels)
+label:bug label:priority    # Has BOTH labels (AND)
+label:bug,enhancement       # Has EITHER label (OR)
+-label:wontfix              # Does NOT have label
+milestone:"v2.0"            # In milestone
+project:github/57           # In project board
+type:"Bug"                  # Issue type
+```
+
+### Missing Metadata
+
+```
+no:label              # No labels assigned
+no:milestone          # No milestone
+no:assignee           # Unassigned
+no:project            # Not in any project
+```
+
+### Dates
+
+All date qualifiers support `>`, `<`, `>=`, `<=`, and range (`..`) operators with ISO 8601 format:
+
+```
+created:>2026-01-01              # Created after Jan 1
+updated:>=2026-03-01             # Updated since Mar 1
+closed:2026-01-01..2026-02-01   # Closed in January
+created:<2026-01-01              # Created before Jan 1
+```
+
+### Linked Content
+
+```
+linked:pr             # Issue has a linked PR
+-linked:pr            # Issues not yet linked to any PR
+linked:issue          # PR is linked to an issue
+```
+
+### Numeric Filters
+
+```
+comments:>10          # More than 10 comments
+comments:0            # No comments
+interactions:>100     # Reactions + comments > 100
+reactions:>50         # More than 50 reactions
+```
+
+### Boolean Logic & Nesting
+
+Use `AND`, `OR`, and parentheses (up to 5 levels deep, max 5 operators):
+
+```
+label:bug AND assignee:octocat
+assignee:octocat OR assignee:hubot
+(type:"Bug" AND label:P1) OR (type:"Feature" AND label:P1)
+-author:app/dependabot          # Exclude bot issues
+```
+
+A space between terms without an explicit operator is treated as AND.
+
+## Common Query Patterns
+
+**Unassigned bugs:**
+```
+repo:owner/repo type:"Bug" no:assignee is:open
+```
+
+**Issues closed this week:**
+```
+repo:owner/repo is:closed closed:>=2026-03-01
+```
+
+**Stale open issues (no updates in 90 days):**
+```
+repo:owner/repo is:open updated:<2026-01-01
+```
+
+**Open issues without a linked PR (needs work):**
+```
+repo:owner/repo is:open -linked:pr
+```
+
+**Issues I'm involved in across an org:**
+```
+org:github involves:@me is:open
+```
+
+**High-activity issues:**
+```
+repo:owner/repo is:open comments:>20
+```
+
+**Issues by type and priority label:**
+```
+repo:owner/repo type:"Epic" label:P1 is:open
+```
+
+## Issue Field Search
+
+> **Reliability warning:** The `field.name:value` search qualifier syntax is experimental and may return 0 results even when matching issues exist. For reliable filtering by field values, use the GraphQL bulk query approach documented in [issue-fields.md](issue-fields.md#searching-by-field-values).
+
+Issue fields can theoretically be searched via the `field.name:value` qualifier using **advanced search mode**. This works in the web UI but results from the API are inconsistent.
+
+### REST API
+
+Add `advanced_search=true` as a query parameter:
+
+```bash
+gh api "search/issues?q=org:github+field.priority:P0+type:Epic+is:open&advanced_search=true" \
+  --jq '.items[] | "#\(.number): \(.title)"'
+```
+
+### GraphQL
+
+Use `type: ISSUE_ADVANCED` instead of `type: ISSUE`:
+
+```graphql
+{
+  search(query: "org:github field.priority:P0 type:Epic is:open", type: ISSUE_ADVANCED, first: 10) {
+    issueCount
+    nodes {
+      ... on Issue { number title }
+    }
+  }
+}
+```
+
+### Issue Field Qualifiers
+
+The syntax uses **dot notation** with the field's slug name (lowercase, hyphens for spaces):
+
+```
+field.priority:P0                  # Single-select field equals value
+field.priority:P1                  # Different option value
+field.target-date:>=2026-04-01     # Date comparison
+has:field.priority                 # Has any value set
+no:field.priority                  # Has no value set
+```
+
+**MCP limitation:** The `search_issues` MCP tool does not pass `advanced_search=true`. You must use `gh api` directly for issue field searches.
+
+### Common Field Search Patterns
+
+**P0 epics across an org:**
+```
+org:github field.priority:P0 type:Epic is:open
+```
+
+**Issues with a target date this quarter:**
+```
+org:github field.target-date:>=2026-04-01 field.target-date:<=2026-06-30 is:open
+```
+
+**Open bugs missing priority:**
+```
+org:github no:field.priority type:Bug is:open
+```
+
+## Limitations
+
+- Query text: max **256 characters** (excluding operators/qualifiers)
+- Boolean operators: max **5** AND/OR/NOT per query
+- Results: max **1,000** total (use `list_issues` if you need all issues)
+- Repo scan: searches up to **4,000** matching repositories
+- Rate limit: **30 requests/minute** for authenticated search
+- Issue field search requires `advanced_search=true` (REST) or `ISSUE_ADVANCED` (GraphQL); not available through MCP `search_issues`

--- a/.agents/skills/github-issues/references/sub-issues.md
+++ b/.agents/skills/github-issues/references/sub-issues.md
@@ -1,0 +1,137 @@
+# Sub-Issues and Parent Issues
+
+Sub-issues let you break down work into hierarchical tasks. Each parent issue can have up to 100 sub-issues, nested up to 8 levels deep. Sub-issues can span repositories within the same owner.
+
+## Recommended Workflow
+
+The simplest way to create a sub-issue is **two steps**: create the issue, then link it.
+
+```bash
+# Step 1: Create the issue and capture its numeric ID
+ISSUE_ID=$(gh api repos/{owner}/{repo}/issues \
+  -X POST \
+  -f title="Sub-task title" \
+  -f body="Description" \
+  --jq '.id')
+
+# Step 2: Link it as a sub-issue of the parent
+# IMPORTANT: sub_issue_id must be an integer. Use --input (not -f) to send JSON.
+echo "{\"sub_issue_id\": $ISSUE_ID}" | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues -X POST --input -
+```
+
+**Why `--input` instead of `-f`?** The `gh api -f` flag sends all values as strings, but the API requires `sub_issue_id` as an integer. Using `-f sub_issue_id=12345` will return a 422 error.
+
+Alternatively, use GraphQL `createIssue` with `parentIssueId` to do it in one step (see GraphQL section below).
+
+## Using MCP tools
+
+**List sub-issues:**
+Call `mcp__github__issue_read` with `method: "get_sub_issues"`, `owner`, `repo`, and `issue_number`.
+
+**Create an issue as a sub-issue:**
+There is no MCP tool for creating sub-issues directly. Use the workflow above or GraphQL.
+
+## Using REST API
+
+**List sub-issues:**
+```bash
+gh api repos/{owner}/{repo}/issues/{issue_number}/sub_issues
+```
+
+**Get parent issue:**
+```bash
+gh api repos/{owner}/{repo}/issues/{issue_number}/parent
+```
+
+**Add an existing issue as a sub-issue:**
+```bash
+# sub_issue_id is the numeric issue ID (not the issue number)
+# Get it from the .id field when creating or fetching an issue
+echo '{"sub_issue_id": 12345}' | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues -X POST --input -
+```
+
+To move a sub-issue that already has a parent, add `"replace_parent": true` to the JSON body.
+
+**Remove a sub-issue:**
+```bash
+echo '{"sub_issue_id": 12345}' | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issue -X DELETE --input -
+```
+
+**Reprioritize a sub-issue:**
+```bash
+echo '{"sub_issue_id": 6, "after_id": 5}' | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues/priority -X PATCH --input -
+```
+
+Use `after_id` or `before_id` to position the sub-issue relative to another.
+
+## Using GraphQL
+
+**Read parent and sub-issues:**
+```graphql
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      parent { number title }
+      subIssues(first: 50) {
+        nodes { number title state }
+      }
+      subIssuesSummary { total completed percentCompleted }
+    }
+  }
+}
+```
+
+**Add a sub-issue:**
+```graphql
+mutation {
+  addSubIssue(input: {
+    issueId: "PARENT_NODE_ID"
+    subIssueId: "CHILD_NODE_ID"
+  }) {
+    issue { id }
+    subIssue { id number title }
+  }
+}
+```
+
+You can also use `subIssueUrl` instead of `subIssueId` (pass the issue's HTML URL). Add `replaceParent: true` to move a sub-issue from another parent.
+
+**Create an issue directly as a sub-issue:**
+```graphql
+mutation {
+  createIssue(input: {
+    repositoryId: "REPO_NODE_ID"
+    title: "Implement login validation"
+    parentIssueId: "PARENT_NODE_ID"
+  }) {
+    issue { id number }
+  }
+}
+```
+
+**Remove a sub-issue:**
+```graphql
+mutation {
+  removeSubIssue(input: {
+    issueId: "PARENT_NODE_ID"
+    subIssueId: "CHILD_NODE_ID"
+  }) {
+    issue { id }
+  }
+}
+```
+
+**Reprioritize a sub-issue:**
+```graphql
+mutation {
+  reprioritizeSubIssue(input: {
+    issueId: "PARENT_NODE_ID"
+    subIssueId: "CHILD_NODE_ID"
+    afterId: "OTHER_CHILD_NODE_ID"
+  }) {
+    issue { id }
+  }
+}
+```
+
+Use `afterId` or `beforeId` to position relative to another sub-issue.

--- a/.agents/skills/github-issues/references/templates.md
+++ b/.agents/skills/github-issues/references/templates.md
@@ -1,0 +1,90 @@
+# Issue Templates
+
+Copy and customize these templates for issue bodies.
+
+## Bug Report Template
+
+```markdown
+## Description
+[Clear description of the bug]
+
+## Steps to Reproduce
+1. [First step]
+2. [Second step]
+3. [And so on...]
+
+## Expected Behavior
+[What should happen]
+
+## Actual Behavior
+[What actually happens]
+
+## Environment
+- Browser: [e.g., Chrome 120]
+- OS: [e.g., macOS 14.0]
+- Version: [e.g., v1.2.3]
+
+## Screenshots/Logs
+[If applicable]
+
+## Additional Context
+[Any other relevant information]
+```
+
+## Feature Request Template
+
+```markdown
+## Summary
+[One-line description of the feature]
+
+## Motivation
+[Why is this feature needed? What problem does it solve?]
+
+## Proposed Solution
+[How should this feature work?]
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+## Alternatives Considered
+[Other approaches considered and why they weren't chosen]
+
+## Additional Context
+[Mockups, examples, or related issues]
+```
+
+## Task Template
+
+```markdown
+## Objective
+[What needs to be accomplished]
+
+## Details
+[Detailed description of the work]
+
+## Checklist
+- [ ] [Subtask 1]
+- [ ] [Subtask 2]
+- [ ] [Subtask 3]
+
+## Dependencies
+[Any blockers or related work]
+
+## Notes
+[Additional context or considerations]
+```
+
+## Minimal Template
+
+For simple issues:
+
+```markdown
+## Description
+[What and why]
+
+## Tasks
+- [ ] [Task 1]
+- [ ] [Task 2]
+```

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'botantler[bot]' || github.event.pull_request.user.login == 'devantler' || github.event.pull_request.user.login == 'Copilot') }}
+    if: ${{ !github.event.pull_request.draft && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'botantler[bot]' || github.event.pull_request.user.login == 'ksail-bot[bot]' || github.event.pull_request.user.login == 'devantler' || github.event.pull_request.user.login == 'Copilot') }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0


### PR DESCRIPTION
## Summary

Two related improvements to the repository:

### Fix: `ksail-bot[bot]` auto-merge

PRs from `ksail-bot[bot]` were not being auto-approved or auto-merged because the bot's login was missing from the `if` condition in `enable-auto-merge.yaml`. This adds it alongside the existing trusted actors (`dependabot[bot]`, `renovate[bot]`, `botantler[bot]`, `devantler`, `Copilot`).

### Feat: install Copilot skills

The repository had no agent skills installed. The following project-scoped skills from [`devantler-tech/skills`](https://github.com/devantler-tech/skills) are now installed under `.agents/skills/`:

| Skill | Source |
|-------|--------|
| `find-skills` | `vercel-labs/skills` |
| `gh-cli` | `github/awesome-copilot` |
| `gh-stack` | `github/gh-stack` |
| `git-commit` | `github/awesome-copilot` |
| `github-actions-docs` | `xixu-me/skills` |
| `github-issues` | `github/awesome-copilot` |

Skipped as irrelevant to this repo: GitOps/Kubernetes, Go, Frontend/Design, and Copilot SDK skills.