### PR TITLE
Update enable-auto-merge.yaml

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -20,7 +20,8 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow for enabling auto-merge. The workflow will now only run for actual pull request events and not for other event types, in addition to skipping draft pull requests.

- Workflow execution condition updated: The `if` condition in `.github/workflows/enable-auto-merge.yaml` was changed to ensure the workflow only runs on `pull_request` events and not on other event types, while still excluding draft pull requests.
