### PR TITLE
fix(create-release): use client-id input and pin semantic-release@25

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          client-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 📑 Checkout

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -32,7 +32,12 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
       - name: 🎉 Release
-        run: npx semantic-release@25 ${{ inputs.dry-run && '--dry-run' || '' }}
+        run: npx semantic-release@25.0.3 ${{ inputs.dry-run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 📑 Checkout
@@ -33,6 +33,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: 🎉 Release
-        run: npx semantic-release ${{ inputs.dry-run && '--dry-run' || '' }}
+        run: npx semantic-release@25 ${{ inputs.dry-run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The release workflow had two issues causing warnings in CI:

- `actions/create-github-app-token@v3.1.1` deprecated the `app-id` input in favor of `client-id` -- this change migrates to the new input name.
- `npx semantic-release` without a version pin was installing v24.2.9, which pulls in the deprecated `semver-diff@5.0.0` package -- this change pins to `semantic-release@25`.

## Type of change

- [x] 🪲 Bug fix