### PR TITLE
feat: add publish-app reusable workflow for OCI-native app delivery

### DIFF
--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -31,6 +31,16 @@ jobs:
       REGISTRY: ${{ inputs.registry }}
       IMAGE_NAME: ${{ github.repository }}
     steps:
+      - name: 🔒 Require a v* tag
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REF_TYPE" != "tag" ] || [ "${REF_NAME#v}" = "$REF_NAME" ]; then
+            echo "::error::publish-app must be invoked from a v* tag (got $REF_TYPE/$REF_NAME); semver artifact selection depends on it."
+            exit 1
+          fi
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -77,7 +87,17 @@ jobs:
           APP_NAME: ${{ inputs.app-name }}
           DEPLOY_PATH: ${{ inputs.deploy-path }}
         run: |
-          yq -i '(.spec.template.spec.containers[] | select(.name == strenv(APP_NAME)).image) = strenv(IMAGE) + "@" + strenv(DIGEST)' "${DEPLOY_PATH}/deployment.yaml"
+          set -euo pipefail
+          file="${DEPLOY_PATH}/deployment.yaml"
+          if [ -z "$DIGEST" ]; then
+            echo "::error::build did not produce an image digest"; exit 1
+          fi
+          matches=$(yq '[.spec.template.spec.containers[] | select(.name == strenv(APP_NAME))] | length' "$file")
+          if [ "$matches" != "1" ]; then
+            echo "::error::expected exactly one container named '$APP_NAME' in $file, found $matches"; exit 1
+          fi
+          yq -i '(.spec.template.spec.containers[] | select(.name == strenv(APP_NAME)).image) = strenv(IMAGE) + "@" + strenv(DIGEST)' "$file"
+          grep -qF "${IMAGE}@${DIGEST}" "$file" || { echo "::error::image pin did not apply to $file"; exit 1; }
 
       - name: 📦 Push & sign manifests artifact
         env:

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -31,6 +31,11 @@ jobs:
       REGISTRY: ${{ inputs.registry }}
       IMAGE_NAME: ${{ github.repository }}
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🔒 Require a v* tag
         env:
           REF_TYPE: ${{ github.ref_type }}

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -1,0 +1,104 @@
+name: 📦 Publish App
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: "Container name in the deployment manifest to pin to the built image digest."
+        required: true
+        type: string
+      deploy-path:
+        description: "Path to the Kubernetes manifests directory packaged as the OCI artifact."
+        required: false
+        default: ./deploy
+        type: string
+      registry:
+        description: "OCI registry to publish the image and manifests artifact to."
+        required: false
+        default: ghcr.io
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish image & manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      packages: write # push image + manifests OCI artifact
+      id-token: write # keyless cosign signing (Fulcio/Rekor via GitHub OIDC)
+    env:
+      REGISTRY: ${{ inputs.registry }}
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🔐 Log in to registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ env.GH_TOKEN }}
+
+      - name: 🏷️ Derive image tags
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=latest
+
+      - name: 🐳 Build & push image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        id: build
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: ⚙️ Setup Flux CLI
+        uses: fluxcd/flux2/action@1fd61a06264d71cf445ed55c4f14d401d26a1c64 # v2.8.8
+
+      - name: ✍️ Setup Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: 📌 Pin image digest in manifests
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          APP_NAME: ${{ inputs.app-name }}
+          DEPLOY_PATH: ${{ inputs.deploy-path }}
+        run: |
+          yq -i '(.spec.template.spec.containers[] | select(.name == strenv(APP_NAME)).image) = strenv(IMAGE) + "@" + strenv(DIGEST)' "${DEPLOY_PATH}/deployment.yaml"
+
+      - name: 📦 Push & sign manifests artifact
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DEPLOY_PATH: ${{ inputs.deploy-path }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+          ARTIFACT="${REGISTRY}/${IMAGE_NAME}/manifests"
+          flux push artifact "oci://${ARTIFACT}:${VERSION}" \
+            --path="${DEPLOY_PATH}" \
+            --source="${SERVER_URL}/${REPOSITORY}" \
+            --revision="${REF_NAME}@sha1:${SHA}" \
+            --creds "${ACTOR}:${GH_TOKEN}"
+          flux tag artifact "oci://${ARTIFACT}:${VERSION}" --tag latest --creds "${ACTOR}:${GH_TOKEN}"
+          cosign sign --yes "${ARTIFACT}:${VERSION}"
+          cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -11,11 +11,6 @@ on:
         required: false
         default: ./deploy
         type: string
-      registry:
-        description: "OCI registry to publish the image and manifests artifact to."
-        required: false
-        default: ghcr.io
-        type: string
 
 permissions: {}
 
@@ -28,7 +23,7 @@ jobs:
       packages: write # push image + manifests OCI artifact
       id-token: write # keyless cosign signing (Fulcio/Rekor via GitHub OIDC)
     env:
-      REGISTRY: ${{ inputs.registry }}
+      REGISTRY: ghcr.io # auth uses GITHUB_TOKEN, which is GHCR-scoped
       IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: 🛡️ Harden runner
@@ -41,8 +36,8 @@ jobs:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "$REF_TYPE" != "tag" ] || [ "${REF_NAME#v}" = "$REF_NAME" ]; then
-            echo "::error::publish-app must be invoked from a v* tag (got $REF_TYPE/$REF_NAME); semver artifact selection depends on it."
+          if [ "$REF_TYPE" != "tag" ] || ! printf '%s' "$REF_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::publish-app must be invoked from a semver tag vX.Y.Z (got $REF_TYPE/$REF_NAME); docker semver tagging and Flux OCIRepository semver selection depend on it."
             exit 1
           fi
 
@@ -96,6 +91,9 @@ jobs:
           file="${DEPLOY_PATH}/deployment.yaml"
           if [ -z "$DIGEST" ]; then
             echo "::error::build did not produce an image digest"; exit 1
+          fi
+          if [ ! -f "$file" ]; then
+            echo "::error::manifest $file not found (check the deploy-path input)"; exit 1
           fi
           matches=$(yq '[.spec.template.spec.containers[] | select(.name == strenv(APP_NAME))] | length' "$file")
           if [ "$matches" != "1" ]; then


### PR DESCRIPTION
## Summary

Adds a `publish-app` reusable workflow so app repos (wedding-app, ascoachingogvaner, …) stop hand-rolling their CD. It implements the Flux OCI-artifacts pattern end to end.

On a `v*` tag, the workflow:
1. Builds & pushes the container image (`semver`, `sha`, `latest` tags).
2. Pins the **built digest** into `deploy/deployment.yaml` (so each release is a distinct, immutable Deployment that actually rolls).
3. Publishes the manifests as a **semver-tagged** OCI artifact (`…/manifests:<version>`) plus a moving `latest`, with `--source`/`--revision` metadata.
4. Keyless **cosign-signs** the image and the manifests artifact (Fulcio/Rekor via GitHub OIDC — no key material to manage).

Consumed by the platform via `OCIRepository.spec.ref.semver`, which auto-selects the newest version — that is the "image automation", OCI-native, no `ImageUpdateAutomation` / Git write-back.

## Tenant usage

```yaml
jobs:
  publish:
    permissions:
      contents: read
      packages: write
      id-token: write   # keyless cosign
    uses: devantler-tech/reusable-workflows/.github/workflows/publish-app.yaml@main
    with:
      app-name: wedding-app
```

## Notes

- All third-party actions are hash-pinned (cosign-installer resolved to v4.1.2 `6f9f1778…`); registry token routed through `env:` for the `secrets-outside-env` rule.
- The signing identity for all tenants is this single workflow, which makes the platform-side cosign `verify` config uniform — see the platform PR.

## Test plan

- [ ] Merge, then a tenant release exercises it end to end (image + signed semver manifests artifact in GHCR).
- [ ] `cosign verify` the published artifact resolves the GitHub OIDC identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)