### PR TITLE
feat: upload Go coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
 
   test-run-dotnet-tests:
     name: "[Test] Run .NET Tests"

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -439,9 +439,8 @@ jobs:
 
       # Uploads to GitHub Code Quality (native PR coverage) and — while CODECOV_TOKEN is still
       # provided — also to Codecov, during the coexistence period.
-      # TODO: re-pin to the upload-coverage release tag once devantler-tech/actions#170 ships.
       - name: 📊 Upload coverage
-        uses: devantler-tech/actions/upload-coverage@69fa71c657e076dac9d8ac1adadabfbeeae1f764 # PR #170 (unreleased)
+        uses: devantler-tech/actions/upload-coverage@60d895a7aabe6e3c0247c86a83560656a760ee08 # v3.5.0
         with:
           file: coverage.cobertura.xml
           language: Go

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -411,6 +411,9 @@ jobs:
       && needs.changes.outputs.go == 'true'
     permissions:
       contents: write
+      # Required by upload-coverage to post coverage to GitHub Code Quality. The CALLING workflow
+      # must also grant this (a reusable workflow's token is capped by the caller's grant).
+      code-quality: write
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -430,7 +433,17 @@ jobs:
         run: |
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-      - name: 📄 Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      - name: 🔄 Convert coverage to Cobertura
+        run: |
+          go run github.com/boumenot/gocover-cobertura@v1.5.0 < coverage.txt > coverage.cobertura.xml
+
+      # Uploads to GitHub Code Quality (native PR coverage) and — while CODECOV_TOKEN is still
+      # provided — also to Codecov, during the coexistence period.
+      # TODO: re-pin to the upload-coverage release tag once devantler-tech/actions#170 ships.
+      - name: 📊 Upload coverage
+        uses: devantler-tech/actions/upload-coverage@69fa71c657e076dac9d8ac1adadabfbeeae1f764 # PR #170 (unreleased)
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage.cobertura.xml
+          language: Go
+          label: code-coverage/go
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
+- **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage). When `CODECOV_TOKEN` is supplied it is *also* uploaded to Codecov, during the transition off the external service.
 
 #### Usage
 
@@ -368,18 +369,23 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 jobs:
   go-test:
     uses: devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@{ref} # ref
+    permissions:
+      contents: write
+      code-quality: write # required for GitHub Code Quality coverage upload
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # optional (transitional)
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       pr-owner: ${{ github.event.pull_request.user.login }} # optional
 ```
 
+> **Note:** The calling workflow must grant `code-quality: write` so coverage can be uploaded to GitHub Code Quality. Coverage requires the repo's _Settings → Code quality_ to have coverage enabled.
+
 #### Secrets and Inputs
 
 | Key               | Type           | Default | Required | Description                                                         |
 |-------------------|----------------|---------|----------|---------------------------------------------------------------------|
-| `CODECOV_TOKEN`   | Secret         | -       | No       | Codecov token for uploading coverage reports                        |
+| `CODECOV_TOKEN`   | Secret         | -       | No       | Codecov token. Transitional — coverage now also goes to GitHub Code Quality; omit to use Code Quality only |
 | `APP_PRIVATE_KEY` | Secret         | -       | No       | GitHub App private key for authenticating the workflow              |
 | `pr-owner`        | Input (string) | -       | No       | Pull request author login (used to disable auto-commit for bot PRs) |
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
-- **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage). When `CODECOV_TOKEN` is supplied it is *also* uploaded to Codecov, during the transition off the external service.
+- **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage). When `CODECOV_TOKEN` is supplied, it is *also* uploaded to Codecov, during the transition off the external service.
 
 #### Usage
 


### PR DESCRIPTION
## What

Wires the `validate-go-project` reusable workflow's **Code Coverage** job into GitHub's native [Code Quality PR coverage](https://github.blog/changelog/2026-05-26-code-coverage-in-pull-requests-is-now-in-public-preview/):

1. Converts the Go coverprofile to **Cobertura** with `gocover-cobertura@v1.5.0`.
2. Uploads it via the shared [`devantler-tech/actions/upload-coverage@v3.5.0`](https://github.com/devantler-tech/actions/pull/170).
3. Grants `code-quality: write` on the coverage job.

Codecov stays as a **transitional coexistence** path: `upload-coverage` still forwards to Codecov while `CODECOV_TOKEN` is provided, so nothing regresses for current consumers.

**PR B** of the coverage migration — depends on **PR A** ([devantler-tech/actions#170](https://github.com/devantler-tech/actions/pull/170), released as `v3.5.0`, now pinned).

## ⚠️ Breaking for callers (opt-in via version bump)

Because the coverage job now requests `code-quality: write`, **every caller of `validate-go-project` must grant `code-quality: write`** on its calling job — otherwise the called job exceeds the caller's grant and the whole run fails at **startup** (not just the coverage step). Consumers pin to a tag, so this only bites when they bump to the release containing this change; their bump PRs must add the permission. This PR updates this repo's own `ci.yaml` test caller accordingly, and the README usage example + note.

## Notes

- **Finding-neutral** for zizmor (identical to `main`); `yamllint` clean. `actionlint` ≤1.7.12 falsely flags the new `code-quality` scope — valid per GitHub's docs; this repo's CI doesn't run actionlint.
- **Repo prerequisite:** coverage must be enabled in each consumer's _Settings → Code quality_.
- The coverage job self-skips on this repo, so end-to-end validation happens when a consumer (ksail) bumps the ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)