### PR TITLE
feat(update-copilot-skills): optional App token so update PRs trigger CI

### DIFF
--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -43,6 +43,22 @@ on:
         required: false
         default: false
         type: boolean
+      use-app-token:
+        description: >-
+          When `true`, create the update PR with a GitHub App token (minted from the `APP_ID`
+          variable and the `APP_PRIVATE_KEY` secret) instead of the default `GITHUB_TOKEN`. A PR
+          opened with `GITHUB_TOKEN` does NOT trigger the caller's `on: pull_request`/`push` CI runs,
+          so its required checks never report and it stays blocked; an App token avoids this.
+          Defaults to `false` (previous behaviour using `GITHUB_TOKEN`).
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      APP_PRIVATE_KEY:
+        description: >-
+          GitHub App private key, required only when `use-app-token` is `true`. Paired with the
+          `APP_ID` repository/organization variable to mint an App token for PR creation.
+        required: false
 
 permissions: {}
 
@@ -55,10 +71,19 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: 🔑 Generate GitHub App token
+        id: app-token
+        if: ${{ inputs.use-app-token }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: 🔄 Update installed skills
         id: update
@@ -85,3 +110,5 @@ jobs:
           branch: ${{ inputs.pr-branch }}
           labels: ${{ inputs.pr-labels }}
           delete-branch: true
+          token: ${{ steps.app-token.outputs.token || github.token }}
+          branch-token: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -78,6 +78,11 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Scope the token to least privilege — exactly what this job needs
+          # (checkout read + create-pull-request push/open) — instead of
+          # inheriting the App installation's blanket permissions.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-copilot-skills.yaml
+++ b/.github/workflows/update-copilot-skills.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: 🔄 Update installed skills


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
Skills-sync PRs opened by this reusable workflow never trigger the caller's CI, so their required checks never report and the PR stays permanently `BLOCKED`. Root cause: the workflow creates the PR with the default `GITHUB_TOKEN`, and **GitHub suppresses `on: pull_request`/`push` events for PRs made with `GITHUB_TOKEN`** (recursion guard). The caller's CI (which posts the required check) therefore never runs.

Observed on [plugins #9](https://github.com/devantler-tech/plugins/pull/9) (2026-05-26): created by `github-actions[bot]` via `GITHUB_TOKEN`; CodeQL/Analyze ran (code-scanning default setup) but `CI - Required Checks` was missing → BLOCKED. The manual unblock was close+reopen with a user token; this makes it durable.

## Fix (backward-compatible, opt-in)
Add an optional App-token path, mirroring the existing `sync-cluster-policies.yaml` convention in this repo:
- New input `use-app-token` (boolean, default `false`).
- New optional secret `APP_PRIVATE_KEY`.
- When `use-app-token: true`, mint a token via `actions/create-github-app-token` (`app-id: vars.APP_ID`, `private-key: secrets.APP_PRIVATE_KEY`) and pass it to `checkout` and `peter-evans/create-pull-request` (`token` + `branch-token`). PRs created with an App token DO trigger the caller's CI.
- The `${{ steps.app-token.outputs.token || github.token }}` fallback preserves current behaviour when `use-app-token` is `false`.

**No caller breaks:** all 4 callers (ksail, plugins, platform, this repo's CI dry-run) keep working unchanged; the App-token path is strictly opt-in.

Kept `app-id: vars.APP_ID` to match the org's existing `sync-cluster-policies.yaml` (`create-github-app-token` now prefers `client-id`, but that's a separate org-wide migration).

## Follow-up (after this merges + a release is cut)
Bump the plugins caller (`devantler-tech/plugins/.github/workflows/update-copilot-skills.yaml`, currently pinned `@v3.2.0`) to the new version and set `use-app-token: true` + `secrets: APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}`. Then skills-sync PRs trigger CI on their own and plugins' `🔀 Enable Auto-Merge` finishes them.

## Validation
`actionlint` passes locally; YAML parses clean. ⚠️ **GitHub Actions is in a major outage right now** ("Incident with Actions and Pages"), so the runtime trigger behaviour can't be confirmed yet. Opened as a **draft** — validate against a real skills-sync run once Actions recovers before promoting/merging.
