### PR TITLE
feat: upload .NET coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -19,6 +19,9 @@ jobs:
     permissions:
       contents: read
       packages: read
+      # Required for the GitHub Code Quality coverage upload. Callers of this reusable workflow
+      # must also grant code-quality:write, or the run fails at startup.
+      code-quality: write
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -32,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/run-dotnet-tests@59d3ffbe1a9437fcc39e2794fa2f221abe878310 # v3.3.0
+        uses: devantler-tech/actions/run-dotnet-tests@31d3c2706ca08bb65fc26002d63a8483965b6570 # v3.6.0
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -5,8 +5,9 @@ permissions: {}
 on:
   workflow_call:
     secrets:
+      # Optional/transitional: when omitted, coverage goes to GitHub Code Quality only.
       CODECOV_TOKEN:
-        required: true
+        required: false
       APP_PRIVATE_KEY:
         required: true
   ### Required Workflow Triggers ###
@@ -20,7 +21,7 @@ jobs:
       contents: read
       packages: read
       # Required for the GitHub Code Quality coverage upload. Callers of this reusable workflow
-      # must also grant code-quality:write, or the run fails at startup.
+      # must also grant `code-quality: write`, or the run fails at startup.
       code-quality: write
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ jobs:
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/run-dotnet-tests.yaml](.github/workflows/run-dotnet-tests.yaml) is a workflow used to test .NET solutions or projects across multiple operating systems.
+[.github/workflows/run-dotnet-tests.yaml](.github/workflows/run-dotnet-tests.yaml) is a workflow used to test .NET solutions or projects across multiple operating systems. Coverage is merged into a single Cobertura report and uploaded to **GitHub Code Quality** (native PR coverage), and — while `CODECOV_TOKEN` is supplied — also to Codecov during the transition off the external service.
 
 #### Usage
 
@@ -219,10 +219,16 @@ jobs:
 jobs:
   dotnet-test:
     uses: devantler-tech/reusable-workflows/.github/workflows/run-dotnet-tests.yaml@{ref} # ref
+    permissions:
+      contents: read
+      packages: read
+      code-quality: write # required for GitHub Code Quality coverage upload
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 ```
+
+> **Note:** The calling workflow must grant `code-quality: write` (otherwise the run fails at startup). Coverage requires the repo's _Settings → Code quality_ to have coverage enabled.
 
 #### Secrets and Inputs
 

--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ jobs:
 
 #### Secrets and Inputs
 
-| Key               | Type   | Default | Required | Description            |
-|-------------------|--------|---------|----------|------------------------|
-| `CODECOV_TOKEN`   | Secret | -       | Yes      | Codecov token          |
-| `APP_PRIVATE_KEY` | Secret | -       | Yes      | GitHub App private key |
+| Key               | Type   | Default | Required | Description                                                                 |
+|-------------------|--------|---------|----------|-----------------------------------------------------------------------------|
+| `CODECOV_TOKEN`   | Secret | -       | No       | Codecov token. Transitional — coverage now also goes to GitHub Code Quality; omit to use Code Quality only |
+| `APP_PRIVATE_KEY` | Secret | -       | Yes      | GitHub App private key                                                      |
 
 </details>
 


### PR DESCRIPTION
## What

Activates GitHub Code Quality coverage for the **.NET** reusable workflow (the counterpart to PR #239's Go path):

1. Bumps `run-dotnet-tests` from `v3.3.0` → **`v3.6.0`** (which merges per-project Cobertura and uploads to GitHub Code Quality — see [actions#174](https://github.com/devantler-tech/actions/pull/174)).
2. Grants `code-quality: write` to the `test` job, and to this repo's own `ci.yaml` `test-run-dotnet-tests` caller.

**PR E** of the coverage migration.

## ⚠️ Breaking for callers (opt-in via version bump)

Same as the Go path: callers of `run-dotnet-tests.yaml` must now grant `code-quality: write`, or the run fails at **startup**. Consumers pin to a tag, so this only applies when they bump. README usage + note updated.

## Notes

- The `.NET` upload itself is best-effort in the action (`continue-on-error`), so even with the permission a preview hiccup won't fail CI; Codecov is unchanged.
- `yamllint` + zizmor clean. `actionlint` ≤1.7.12 falsely flags `code-quality`.
- **Repo prerequisite:** coverage enabled in _Settings → Code quality_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)