### PR TITLE
fix: make Go coverage upload best-effort (never block PRs)

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -433,13 +433,17 @@ jobs:
         run: |
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
+      # best-effort: coverage reporting is a preview feature and must never block a Go PR. This job
+      # runs on every Go PR org-wide via the required-workflow ruleset (pinned to this repo's main).
       - name: 🔄 Convert coverage to Cobertura
+        continue-on-error: true
         run: |
           go run github.com/boumenot/gocover-cobertura@v1.5.0 < coverage.txt > coverage.cobertura.xml
 
       # Uploads to GitHub Code Quality (native PR coverage) and — while CODECOV_TOKEN is still
       # provided — also to Codecov, during the coexistence period.
       - name: 📊 Upload coverage
+        continue-on-error: true
         uses: devantler-tech/actions/upload-coverage@60d895a7aabe6e3c0247c86a83560656a760ee08 # v3.5.0
         with:
           file: coverage.cobertura.xml


### PR DESCRIPTION
## What

Marks the `validate-go-project` Cobertura-conversion and upload steps `continue-on-error: true`, so the coverage feature can never fail a Go PR.

## Why (urgent)

The org rulesets pin the required Go/.NET workflows to **`refs/heads/main`** of this repo (not a version tag). So [#239](https://github.com/devantler-tech/reusable-workflows/pull/239)'s coverage job already runs on **every Go PR across the org**. The new `gocover-cobertura` conversion step had no error guard — a single transient failure (module fetch, etc.) would have blocked Go PRs portfolio-wide. This brings the Go path in line with the .NET path, which was already best-effort.

Coverage reporting is a preview feature; it must never gate CI.

## Notes

- Finding-neutral for zizmor (identical to `main`); `yamllint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)