### PR TITLE
feat!: remove Codecov from the coverage reusable workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,6 @@ jobs:
       packages: read
       code-quality: write # callers must grant this for the coverage upload (GitHub Code Quality)
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   test-enable-auto-merge:

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -5,9 +5,6 @@ permissions: {}
 on:
   workflow_call:
     secrets:
-      # Optional/transitional: when omitted, coverage goes to GitHub Code Quality only.
-      CODECOV_TOKEN:
-        required: false
       APP_PRIVATE_KEY:
         required: true
   ### Required Workflow Triggers ###
@@ -36,9 +33,8 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/run-dotnet-tests@31d3c2706ca08bb65fc26002d63a8483965b6570 # v3.6.0
+        uses: devantler-tech/actions/run-dotnet-tests@7dbc3c310c46eb51b0f298de2de0e2d9c6552eae # v4.0.0
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -8,9 +8,6 @@ on:
         type: string
         description: "Pull request author login (used to disable auto-commit for bot PRs)"
     secrets:
-      CODECOV_TOKEN:
-        required: false
-        description: "Codecov token for uploading coverage reports"
       APP_PRIVATE_KEY:
         description: "GitHub App Private Key"
         required: false
@@ -440,13 +437,11 @@ jobs:
         run: |
           go run github.com/boumenot/gocover-cobertura@v1.5.0 < coverage.txt > coverage.cobertura.xml
 
-      # Uploads to GitHub Code Quality (native PR coverage) and — while CODECOV_TOKEN is still
-      # provided — also to Codecov, during the coexistence period.
+      # Uploads coverage to GitHub Code Quality (native PR coverage). best-effort: never blocks CI.
       - name: 📊 Upload coverage
         continue-on-error: true
-        uses: devantler-tech/actions/upload-coverage@60d895a7aabe6e3c0247c86a83560656a760ee08 # v3.5.0
+        uses: devantler-tech/actions/upload-coverage@7dbc3c310c46eb51b0f298de2de0e2d9c6552eae # v4.0.0
         with:
           file: coverage.cobertura.xml
           language: Go
           label: code-coverage/go
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ jobs:
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/run-dotnet-tests.yaml](.github/workflows/run-dotnet-tests.yaml) is a workflow used to test .NET solutions or projects across multiple operating systems. Coverage is merged into a single Cobertura report and uploaded to **GitHub Code Quality** (native PR coverage), and — while `CODECOV_TOKEN` is supplied — also to Codecov during the transition off the external service.
+[.github/workflows/run-dotnet-tests.yaml](.github/workflows/run-dotnet-tests.yaml) is a workflow used to test .NET solutions or projects across multiple operating systems. Coverage is merged into a single Cobertura report and uploaded to **GitHub Code Quality** (native PR coverage).
 
 #### Usage
 
@@ -224,18 +224,16 @@ jobs:
       packages: read
       code-quality: write # required for GitHub Code Quality coverage upload
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 
-> **Note:** The calling workflow must grant `code-quality: write` (otherwise the run fails at startup). Coverage requires the repo's _Settings → Code quality_ to have coverage enabled.
+> **Note:** The calling workflow must grant `code-quality: write` (otherwise the run fails at startup). Coverage requires the repo's **Code Quality** to be enabled (_Settings → Code quality_).
 
 #### Secrets and Inputs
 
-| Key               | Type   | Default | Required | Description                                                                 |
-|-------------------|--------|---------|----------|-----------------------------------------------------------------------------|
-| `CODECOV_TOKEN`   | Secret | -       | No       | Codecov token. Transitional — coverage now also goes to GitHub Code Quality; omit to use Code Quality only |
-| `APP_PRIVATE_KEY` | Secret | -       | Yes      | GitHub App private key                                                      |
+| Key               | Type   | Default | Required | Description            |
+|-------------------|--------|---------|----------|------------------------|
+| `APP_PRIVATE_KEY` | Secret | -       | Yes      | GitHub App private key |
 
 </details>
 
@@ -367,7 +365,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
-- **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage). When `CODECOV_TOKEN` is supplied, it is *also* uploaded to Codecov, during the transition off the external service.
+- **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage).
 
 #### Usage
 
@@ -379,19 +377,17 @@ jobs:
       contents: write
       code-quality: write # required for GitHub Code Quality coverage upload
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # optional (transitional)
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       pr-owner: ${{ github.event.pull_request.user.login }} # optional
 ```
 
-> **Note:** The calling workflow must grant `code-quality: write` so coverage can be uploaded to GitHub Code Quality. Coverage requires the repo's _Settings → Code quality_ to have coverage enabled.
+> **Note:** The calling workflow must grant `code-quality: write` so coverage can be uploaded to GitHub Code Quality. Coverage requires the repo's **Code Quality** to be enabled (_Settings → Code quality_).
 
 #### Secrets and Inputs
 
 | Key               | Type           | Default | Required | Description                                                         |
 |-------------------|----------------|---------|----------|---------------------------------------------------------------------|
-| `CODECOV_TOKEN`   | Secret         | -       | No       | Codecov token. Transitional — coverage now also goes to GitHub Code Quality; omit to use Code Quality only |
 | `APP_PRIVATE_KEY` | Secret         | -       | No       | GitHub App private key for authenticating the workflow              |
 | `pr-owner`        | Input (string) | -       | No       | Pull request author login (used to disable auto-commit for bot PRs) |
 


### PR DESCRIPTION
## What

Phase 3 (reusable-workflows side) — **retire Codecov**. Bumps both coverage actions to **v4.0.0** (which dropped the `codecov-token` input), and removes the `CODECOV_TOKEN` secret declaration + passthrough from:
- `validate-go-project.yaml` (Go)
- `run-dotnet-tests.yaml` (.NET)
- this repo's own `ci.yaml` `.NET` test caller
- README

GitHub Code Quality is now the sole coverage destination.

## ⚠️ Breaking

`CODECOV_TOKEN` is no longer declared in these reusable workflows, so callers must stop passing it (else startup error). Consumers pin tags, so this only applies on their next bump — the **ksail** caller is updated in the follow-up consumer PR. The org ruleset runs these top-level (`@main`), so the live PR-time path is unaffected.

## Safety

`yamllint` clean; zizmor **finding-neutral** vs `main` (verified per-file: identical unsuppressed counts). The Go/.NET coverage steps remain best-effort, so nothing can block PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)