### PR TITLE
fix(ci): ignore actionlint false positive for code-quality scope

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -319,6 +319,10 @@ jobs:
           APPLY_FIXES: all
           APPLY_FIXES_EVENT: all
           APPLY_FIXES_MODE: commit
+          # actionlint (<=1.7.12, bundled in MegaLinter) doesn't yet know the `code-quality`
+          # permission scope that GitHub Code Quality coverage requires callers to grant, so it
+          # reports a false "unknown permission scope" error. Ignore it until actionlint catches up.
+          ACTION_ACTIONLINT_ARGUMENTS: -ignore code-quality
 
       - name: Commit and push applied linter fixes
         if: |


### PR DESCRIPTION
## What

Adds `ACTION_ACTIONLINT_ARGUMENTS: -ignore code-quality` to the `validate-go-project` MegaLinter step.

## Why

MegaLinter bundles `actionlint v1.7.12`, which doesn't yet know the `code-quality` permission scope (added for GitHub Code Quality coverage). Since `validate-go-project` lints **consumer** workflows, any Go repo that grants `code-quality: write` in its own workflow (e.g. ksail's `ci-go` caller) fails MegaLinter with a false `unknown permission scope "code-quality"` error. This ignores that one false positive until actionlint catches up. Discovered on [ksail#4893](https://github.com/devantler-tech/ksail/pull/4893).

zizmor finding-neutral; yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)