### PR TITLE
feat!: rename update-copilot-skills workflow to update-agent-skills

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,9 +133,9 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
-  test-update-copilot-skills:
-    name: "[Test] Update Copilot Skills - Dry Run"
-    uses: ./.github/workflows/update-copilot-skills.yaml
+  test-update-agent-skills:
+    name: "[Test] Update Agent Skills - Dry Run"
+    uses: ./.github/workflows/update-agent-skills.yaml
     permissions:
       contents: write
       pull-requests: write
@@ -159,7 +159,7 @@ jobs:
         test-publish-dotnet-library,
         test-scan-for-todo-comments,
         test-sync-cluster-policies,
-        test-update-copilot-skills,
+        test-update-agent-skills,
       ]
     permissions: {}
     if: ${{ always() }}
@@ -180,4 +180,4 @@ jobs:
             ${{ needs.test-publish-dotnet-library.result }}
             ${{ needs.test-scan-for-todo-comments.result }}
             ${{ needs.test-sync-cluster-policies.result }}
-            ${{ needs.test-update-copilot-skills.result }}
+            ${{ needs.test-update-agent-skills.result }}

--- a/.github/workflows/update-agent-skills.yaml
+++ b/.github/workflows/update-agent-skills.yaml
@@ -1,4 +1,4 @@
-name: 🔄 Update Copilot Skills
+name: 🔄 Update Agent Skills
 
 on:
   workflow_call:
@@ -22,12 +22,12 @@ on:
         description: Branch the update PR is opened from
         required: false
         type: string
-        default: deps/copilot-skills-update
+        default: deps/agent-skills-update
       pr-title:
         description: Title of the update PR
         required: false
         type: string
-        default: "chore(deps): update copilot skills"
+        default: "chore(deps): update agent skills"
       pr-labels:
         description: Comma-separated labels applied to the update PR
         required: false
@@ -37,7 +37,7 @@ on:
         description: Commit message for the update PR
         required: false
         type: string
-        default: "chore(deps): update copilot skills"
+        default: "chore(deps): update agent skills"
       dry-run:
         description: "Skip update and PR creation (validate workflow interface only)"
         required: false
@@ -63,8 +63,8 @@ on:
 permissions: {}
 
 jobs:
-  update-copilot-skills:
-    name: Update Copilot skills
+  update-agent-skills:
+    name: Update agent skills
     if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-latest
     permissions:
@@ -92,6 +92,9 @@ jobs:
 
       - name: 🔄 Update installed skills
         id: update
+        # TODO: repoint to devantler-tech/actions/update-agent-skills once the action
+        # rename (devantler-tech/actions#178) ships in a release. This pinned SHA still
+        # carries the action under its former name, so it keeps working until then.
         uses: devantler-tech/actions/update-copilot-skills@59d3ffbe1a9437fcc39e2794fa2f221abe878310 # v3.3.0
         with:
           dir: ${{ inputs.dir }}
@@ -105,7 +108,7 @@ jobs:
           commit-message: ${{ inputs.commit-message }}
           title: ${{ inputs.pr-title }}
           body: |
-            Automated update of Copilot skills to their latest versions.
+            Automated update of agent skills to their latest versions.
 
             Updated files under `${{ inputs.dir }}`:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This file is the single canonical instructions file for the repository. It is re
     ├── scan-for-todo-comments.yaml        # Reusable: scan TODOs and create GitHub issues
     ├── scan-for-workflow-vulnerabilities.yaml # Reusable: Zizmor GitHub Actions security analysis
     ├── sync-cluster-policies.yaml         # Reusable: sync Kyverno policies from upstream
-    ├── update-copilot-skills.yaml         # Reusable: keep installed agent skills up-to-date
+    ├── update-agent-skills.yaml           # Reusable: keep installed agent skills up-to-date
     └── validate-go-project.yaml           # Reusable: Go lint, build, test, coverage
 ```
 

--- a/README.md
+++ b/README.md
@@ -309,12 +309,12 @@ jobs:
 
 </details>
 
-### 🔄 Update Copilot Skills
+### 🔄 Update Agent Skills
 
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/update-copilot-skills.yaml](.github/workflows/update-copilot-skills.yaml) is a workflow used to keep installed Copilot / agent skills up-to-date via [`gh skill update --all`](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/), opening a PR with any changes. Each installed `SKILL.md`'s `metadata.github-*` frontmatter is the source of truth — no lockfile is required. Works with any mix of `gh skill`-compatible upstreams.
+[.github/workflows/update-agent-skills.yaml](.github/workflows/update-agent-skills.yaml) is a workflow used to keep installed agent skills (Copilot, Claude Code, …) up-to-date via [`gh skill update --all`](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/), opening a PR with any changes. Each installed `SKILL.md`'s `metadata.github-*` frontmatter is the source of truth — no lockfile is required. Works with any mix of `gh skill`-compatible upstreams.
 
 #### Usage
 
@@ -325,8 +325,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-copilot-skills:
-    uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@{ref} # ref
+  update-agent-skills:
+    uses: devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml@{ref} # ref
     permissions:
       contents: write
       pull-requests: write
@@ -334,7 +334,7 @@ jobs:
       dir: .agents/skills
 ```
 
-The workflow assumes skills were previously installed with [`devantler-tech/actions/setup-copilot-skills`](https://github.com/devantler-tech/actions/tree/main/setup-copilot-skills) (or `gh skill install` directly) — the committed `SKILL.md` files carry the upstream pointers.
+The workflow assumes skills were previously installed with [`devantler-tech/actions/setup-agent-skills`](https://github.com/devantler-tech/actions/tree/main/setup-agent-skills) (or `gh skill install` directly) — the committed `SKILL.md` files carry the upstream pointers.
 
 #### Secrets and Inputs
 
@@ -343,10 +343,10 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 | `dir`            | Input (string)  | `.`                                  | No       | Directory to scan for installed skills (passed to `gh skill update --dir`) |
 | `unpin`          | Input (boolean) | `false`                              | No       | When `true`, pass `--unpin` (clear pinned versions)                    |
 | `gh-version`     | Input (string)  | `2.90.0`                             | No       | Minimum required `gh` version (must support `gh skill`)                |
-| `pr-branch`      | Input (string)  | `deps/copilot-skills-update`         | No       | Branch the update PR is opened from                                    |
-| `pr-title`       | Input (string)  | `chore(deps): update copilot skills` | No       | Title of the update PR                                                 |
+| `pr-branch`      | Input (string)  | `deps/agent-skills-update`           | No       | Branch the update PR is opened from                                    |
+| `pr-title`       | Input (string)  | `chore(deps): update agent skills`   | No       | Title of the update PR                                                 |
 | `pr-labels`      | Input (string)  | `dependencies,automation`            | No       | Comma-separated labels for the update PR                               |
-| `commit-message` | Input (string)  | `chore(deps): update copilot skills` | No       | Commit message for the update PR                                       |
+| `commit-message` | Input (string)  | `chore(deps): update agent skills`   | No       | Commit message for the update PR                                       |
 | `dry-run`        | Input (boolean) | `false`                              | No       | Skip update and PR creation (validate workflow interface only)         |
 
 > **Note:** The calling workflow must grant `contents: write` and `pull-requests: write` permissions.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

`gh skill` is **agent-neutral** — installed `SKILL.md` files work across Copilot, Claude Code, Cursor, … This renames the reusable skill-update workflow to drop the misleading Copilot branding, matching the action rename in [devantler-tech/actions#178](https://github.com/devantler-tech/actions/pull/178).

## What changed

- **Renamed** (history preserved): `.github/workflows/update-copilot-skills.yaml` → **`update-agent-skills.yaml`**.
- Default values reworded `copilot skills` → `agent skills` (`pr-branch` → `deps/agent-skills-update`, `pr-title`/`commit-message` → `chore(deps): update agent skills`). Input/secret **names and types are unchanged** — `workflow_call` interface stays backward-compatible.
- CI test job renamed `test-update-copilot-skills` → `test-update-agent-skills` (still `dry-run: true`).
- `README.md` / `AGENTS.md` updated.

## Ordering / follow-up

The inner step still pins `devantler-tech/actions/update-copilot-skills@59d3ffbe… # v3.3.0` (a historical SHA that still carries the action under its former name, so it keeps working). Once [actions#178](https://github.com/devantler-tech/actions/pull/178) releases the renamed `update-agent-skills` action, a one-line follow-up repoints it (marked with a `TODO` in the file).

## Breaking change

The workflow path `update-copilot-skills.yaml` is **removed**. Consumers pinned to an older ref (e.g. the `devantler-tech/plugins` caller, pinned to a SHA) are unaffected until they bump:

```diff
- uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@<ref>
+ uses: devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml@<ref>
```

## Validation

- `actionlint` clean (only pre-existing `code-quality` permission-scope warnings).
- `zizmor` clean (no findings).