### PR TITLE
ci: repoint update-agent-skills workflow to update-agent-skills@v5.0.0

### DIFF
--- a/.github/workflows/update-agent-skills.yaml
+++ b/.github/workflows/update-agent-skills.yaml
@@ -92,10 +92,7 @@ jobs:
 
       - name: 🔄 Update installed skills
         id: update
-        # TODO: repoint to devantler-tech/actions/update-agent-skills once the action
-        # rename (devantler-tech/actions#178) ships in a release. This pinned SHA still
-        # carries the action under its former name, so it keeps working until then.
-        uses: devantler-tech/actions/update-copilot-skills@59d3ffbe1a9437fcc39e2794fa2f221abe878310 # v3.3.0
+        uses: devantler-tech/actions/update-agent-skills@3556694b57702d81bfc5fb1d79a9ee0b4e53aca7 # v5.0.0
         with:
           dir: ${{ inputs.dir }}
           unpin: ${{ inputs.unpin }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Closes the follow-up from [reusable-workflows#246](https://github.com/devantler-tech/reusable-workflows/pull/246): [actions#178](https://github.com/devantler-tech/actions/pull/178) shipped in **v5.0.0**, renaming the `update-copilot-skills` action to **`update-agent-skills`**.

This repoints the inner step:

```diff
- uses: devantler-tech/actions/update-copilot-skills@59d3ffbe… # v3.3.0
+ uses: devantler-tech/actions/update-agent-skills@3556694b… # v5.0.0
```

The action's inputs (`dir`, `unpin`, `gh-version`) are unchanged, so behaviour is identical — this only removes the deliberate cross-PR TODO and the now-stale Copilot-branded reference.

Validation: `actionlint` clean (only pre-existing `code-quality` scope warnings); `zizmor` clean. The `test-update-agent-skills` CI job runs with `dry-run: true` (the update job is skipped), as before.

### Remaining tidy (optional, separate)
`devantler-tech/plugins` still pins the old reusable-workflow path `update-copilot-skills.yaml@…`; it keeps working via its pin and can be repointed to `update-agent-skills.yaml` after this repo cuts its next release.