### PR TITLE
feat(publish-dotnet-library): provision .NET 10 SDK alongside 9

### DIFF
--- a/.github/workflows/publish-dotnet-library.yaml
+++ b/.github/workflows/publish-dotnet-library.yaml
@@ -31,7 +31,11 @@ jobs:
       - name: ⚙️ Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9
+          # Provision both the previous STS (9) and the current LTS (10) so libraries
+          # targeting either TFM publish cleanly. Multiple lines install side-by-side SDKs.
+          dotnet-version: |
+            9
+            10
 
       - name: 🚚 Publish
         shell: bash


### PR DESCRIPTION
> 🤖 Opened by the Daily AI Assistant (autonomous run).

## What
`publish-dotnet-library.yaml` provisions only the **.NET 9** SDK (`dotnet-version: 9`), so publishing a library targeting **.NET 10** (current LTS) would fail at release time for lack of an SDK.

This PR provisions **both** SDKs side-by-side. Purely additive — net9 libraries are unaffected.

## Change
- `.github/workflows/publish-dotnet-library.yaml` — `dotnet-version` now installs `9` **and** `10`.

## Context
Part of the .NET 10 prerequisite for [devantler-tech/dotnet-template#168](https://github.com/devantler-tech/dotnet-template/issues/168). Pairs with the `run-dotnet-tests` SDK bump in `devantler-tech/actions` which covers the PR-CI (build/test) path; this one covers the publish/release path so a net10 library release stays green.