### PR TITLE
feat(run-dotnet-tests): provision .NET 10 SDK alongside 9

### DIFF
--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test .NET solution or project
-        uses: devantler-tech/actions/run-dotnet-tests@7dbc3c310c46eb51b0f298de2de0e2d9c6552eae # v4.0.0
+        uses: devantler-tech/actions/run-dotnet-tests@6916c45ed8dc22e62cb12f021480e29732d03575 # v5.1.0
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Bump the pinned `devantler-tech/actions/run-dotnet-tests` in `run-dotnet-tests.yaml` from **v4.0.0** (provisions SDK 9 only) → **v5.1.0** (provisions SDK **9 and 10** side-by-side).

```diff
-        uses: devantler-tech/actions/run-dotnet-tests@7dbc3c31…  # v4.0.0
+        uses: devantler-tech/actions/run-dotnet-tests@6916c45e…  # v5.1.0
```

## Why

This is the **final prerequisite link** for [dotnet-template#168](https://github.com/devantler-tech/dotnet-template/issues/168) (bump TFM `net9.0` → `net10.0`, the current LTS). The org "Require workflows for .NET" ruleset runs this workflow at `refs/heads/main` as the PR-CI gate for every .NET consumer (dotnet-template included). While the pin stays at v4.0.0, a `net10.0` build fails with *SDK not found*.

The sibling release-path change ([reusable-workflows#250](https://github.com/devantler-tech/reusable-workflows/pull/250), `publish-dotnet-library.yaml` → SDK 9+10) merged yesterday; it could not also bump this pin because **actions v5.1.0 did not exist yet** ([actions#186](https://github.com/devantler-tech/actions/pull/186), released `v5.1.0` @ 2026-05-28 21:13Z). With v5.1.0 now published, this closes the gap.

Once this lands on `main`, the ruleset immediately provisions SDK 10 (it tracks `main`, no release needed), unblocking the dotnet-template TFM bump.

## Safety / blast radius

- **Backward-compatible.** The action still installs SDK 9; net9 callers are unaffected. `actions/run-dotnet-tests@v5.1.0` was CI-validated green on macos/ubuntu/windows in actions#186.
- One-line pinned-SHA bump; `actionlint` clean (the pre-existing `code-quality` scope warning is the known false-positive suppressed in #244).