### PR TITLE
docs: document publish-app + remove stale lint-documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,28 +155,41 @@ jobs:
 
 </details>
 
-### 🧹 Lint Documentation
+### 📦 Publish App
 
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/lint-documentation.yaml](.github/workflows/lint-documentation.yaml) is a workflow used to lint documentation files using the MegaLinter documentation flavor.
+[.github/workflows/publish-app.yaml](.github/workflows/publish-app.yaml) is a workflow used to build and publish a containerized app and its Kubernetes manifests to GHCR as cosign-signed OCI artifacts. It builds and pushes the container image (tagged `{{version}}`, `sha-<sha>`, and `latest`), pins the built image digest into the deployment manifest's `app-name` container, pushes the manifests directory as a Flux-compatible OCI artifact (`ghcr.io/<repo>/manifests`), and signs both the image and the manifests artifact with keyless cosign (Fulcio/Rekor via GitHub OIDC).
 
 #### Usage
 
 ```yaml
+on:
+  push:
+    tags:
+      - "v*"
+
 jobs:
-  docs-lint:
-    uses: devantler-tech/reusable-workflows/.github/workflows/lint-documentation.yaml@{ref} # ref
-    secrets:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+  publish-app:
+    uses: devantler-tech/reusable-workflows/.github/workflows/publish-app.yaml@{ref} # ref
+    permissions:
+      contents: read # checkout
+      packages: write # push image + manifests OCI artifact
+      id-token: write # keyless cosign signing
+    with:
+      app-name: my-app # container name in deploy/deployment.yaml
+      deploy-path: ./deploy # optional
 ```
+
+> **Note:** Must be invoked from a semver tag (`vX.Y.Z`) — Docker semver tagging and Flux `OCIRepository` semver selection depend on it. The calling job must grant `packages: write` and `id-token: write` (and `contents: read` for checkout); no secrets are required (auth uses the GHCR-scoped `GITHUB_TOKEN`).
 
 #### Secrets and Inputs
 
-| Key               | Type   | Default | Required | Description            |
-|-------------------|--------|---------|----------|------------------------|
-| `APP_PRIVATE_KEY` | Secret | -       | Yes      | GitHub App private key |
+| Key           | Type           | Default    | Required | Description                                                                |
+|---------------|----------------|------------|----------|----------------------------------------------------------------------------|
+| `app-name`    | Input (string) | -          | Yes      | Container name in the deployment manifest to pin to the built image digest |
+| `deploy-path` | Input (string) | `./deploy` | No       | Path to the Kubernetes manifests directory packaged as the OCI artifact    |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ jobs:
 <details>
 <summary>Click to expand</summary>
 
-[.github/workflows/publish-app.yaml](.github/workflows/publish-app.yaml) is a workflow used to build and publish a containerized app and its Kubernetes manifests to GHCR as cosign-signed OCI artifacts. It builds and pushes the container image (tagged `{{version}}`, `sha-<sha>`, and `latest`), pins the built image digest into the deployment manifest's `app-name` container, pushes the manifests directory as a Flux-compatible OCI artifact (`ghcr.io/<repo>/manifests`), and signs both the image and the manifests artifact with keyless cosign (Fulcio/Rekor via GitHub OIDC).
+[.github/workflows/publish-app.yaml](.github/workflows/publish-app.yaml) is a workflow used to build and publish a containerized app and its Kubernetes manifests to GHCR as cosign-signed OCI artifacts. It builds and pushes the container image (tagged with the semantic version derived from the git tag — e.g. `1.2.3` from a `v1.2.3` tag — plus `sha-<sha>` and `latest`), pins the built image digest into the deployment manifest's `app-name` container, pushes the manifests directory as a Flux-compatible OCI artifact (`ghcr.io/<owner>/<repo>/manifests`), and signs both the image and the manifests artifact with keyless cosign (Fulcio/Rekor via GitHub OIDC).
 
 #### Usage
 


### PR DESCRIPTION
Part of #252 · Fixes #254.

## What
Documents the previously-undocumented `publish-app.yaml` reusable workflow in `README.md` and removes a stale catalogue entry.

- **Add `📦 Publish App` section** — `publish-app.yaml` (OCI image + manifests publish with keyless cosign signing) had **zero README mentions**. New section follows the existing collapsible `<details>` catalogue style: usage block (triggered on a `v*` tag, with the required `packages: write` / `id-token: write` / `contents: read` permissions), a note on the semver-tag requirement and that no secrets are needed (GHCR-scoped `GITHUB_TOKEN`), and an inputs table (`app-name` required, `deploy-path` default `./deploy`) — all derived from the workflow's `on: workflow_call` interface.
- **Remove the stale `🧹 Lint Documentation` section** — `lint-documentation.yaml` is no longer in the workflow inventory (confirmed 404), so the README documented a workflow that no longer exists. (The same removed file leaves a stale `zizmor.yml` ignore entry — tracked separately in #256.)

## Audit
Spot-checked the other catalogue entries against their current `on: workflow_call` definitions — `create-release` (`dry-run` + `APP_PRIVATE_KEY`), `publish-dotnet-library` (`dry-run` + optional `NUGET_API_KEY`), and `scan-for-workflow-vulnerabilities` (no inputs) all match. No other parity drift found.

## Acceptance criteria (#254)
- [x] `publish-app.yaml` documented in `README.md`
- [x] README inputs/secrets/outputs match each workflow's `workflow_call` definition

Docs-only; no workflow behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
