### PR TITLE
chore(security): retire the inert secrets-outside-env zizmor ignore block (Fixes #256)

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -6,18 +6,3 @@ rules:
         github/*: ref-pin
         devantler-tech/*: ref-pin
         "*": hash-pin
-  secrets-outside-env:
-    ignore:
-      # Reusable workflows cannot rely on environment secrets consistently.
-      - create-release.yaml:25
-      - enable-auto-merge.yaml:33
-      - lint-documentation.yaml:35
-      - publish-dotnet-library.yaml:40
-      - run-dotnet-tests.yaml:43
-      - run-dotnet-tests.yaml:45
-      - scan-for-todo-comments.yaml:32
-      - sync-cluster-policies.yaml:35
-      - validate-go-project.yaml:147
-      - validate-go-project.yaml:212
-      - validate-go-project.yaml:328
-      - validate-go-project.yaml:476


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Closes the audit asked for in #256 (roadmap #252 — *complete · consistent · secure*).

## What the audit found
`zizmor.yml` carried a `secrets-outside-env` ignore block with **12 line-anchored entries** under one opaque blanket comment. Auditing it against the live toolchain:

1. **`secrets-outside-env` is an `auditor`-persona-only rule.** Our scan job ([`scan-for-workflow-vulnerabilities.yaml`](.github/workflows/scan-for-workflow-vulnerabilities.yaml)) calls `zizmorcore/zizmor-action` **without a `persona` input**, so it runs the action's default **`regular`** persona (`version: latest`). Under the regular persona the rule never fires — so **none of the 12 entries suppress anything in CI**.
2. **One entry was provably stale:** `lint-documentation.yaml:35` — that workflow no longer exists in the repo, so it could not have been suppressing a finding under any version.
3. **The rest were dead too, and line-drifted:** the remaining anchors no longer line up with their original `secrets:` sites (e.g. `create-release.yaml:25` now lands on a `client-id:` input), exactly the silent line-number rot #256 flagged.

Rather than re-document 11 suppressions that suppress nothing, the honest, complete answer to *"re-enable any that no longer need suppression"* is to **retire the whole block**.

## Change
Removed the entire `secrets-outside-env:` block from `zizmor.yml`. The load-bearing `unpinned-uses` policy config is untouched.

## Validation
Reproduced CI's exact invocation locally (zizmor 1.25.2, regular persona, the proposed config):

```
No findings to report. Good job! (49 suppressed)
```

— identical to before (the 49 suppressions are all `unpinned-uses`; the secrets block contributed 0). Emptying the block under both regular **and** auditor persona produced no new `secrets-outside-env` finding.

## Acceptance criteria (#256)
- [x] No `zizmor.yml` ignore references a non-existent workflow — the whole block (incl. `lint-documentation.yaml`) is gone.
- [x] Each remaining suppression has a clear rationale — none remain; `unpinned-uses` is self-describing.
- [x] `scan-for-workflow-vulnerabilities` stays green — verified above.

## Note for the maintainer
If a future zizmor release promotes `secrets-outside-env` into the regular persona, the scan would then surface the real `secrets:`-passthrough sites — which is the correct, visible behaviour, rather than pre-masking them behind rotted line anchors. No action needed now.

---
*Per the autonomy model: opened as a **draft** — promote to ready when you'd like it driven to merge.*