### PR TITLE
test(ci): add a dry-run [Test] job for publish-app.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,6 +113,17 @@ jobs:
     with:
       dry-run: true
 
+  test-publish-app:
+    name: "[Test] Publish App - Dry Run"
+    uses: ./.github/workflows/publish-app.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      app-name: app
+      dry-run: true
+
   test-scan-for-todo-comments:
     name: "[Test] Scan for TODO Comments - Dry Run"
     uses: ./.github/workflows/scan-for-todo-comments.yaml
@@ -168,6 +179,7 @@ jobs:
         test-create-release,
         test-deploy-github-pages,
         test-publish-dotnet-library,
+        test-publish-app,
         test-scan-for-todo-comments,
         test-sync-cluster-policies,
         test-update-agent-skills,
@@ -190,6 +202,7 @@ jobs:
             ${{ needs.test-create-release.result }}
             ${{ needs.test-deploy-github-pages.result }}
             ${{ needs.test-publish-dotnet-library.result }}
+            ${{ needs.test-publish-app.result }}
             ${{ needs.test-scan-for-todo-comments.result }}
             ${{ needs.test-sync-cluster-policies.result }}
             ${{ needs.test-update-agent-skills.result }}

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -11,12 +11,18 @@ on:
         required: false
         default: ./deploy
         type: string
+      dry-run:
+        description: "Skip publish (validate workflow interface only)."
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
 jobs:
   publish:
     name: Publish image & manifests
+    if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #253 (part of the [reusable-workflows roadmap #252](https://github.com/devantler-tech/reusable-workflows/issues/252) — *complete · consistent · secure*).

## Problem
Every reusable workflow has a `[Test]` job in [`ci.yaml`](.github/workflows/ci.yaml) aggregated under `CI - Required Checks` — **except `publish-app.yaml`**, the newest workflow (keyless cosign OCI image + manifests publish). Nothing exercised it on PR, so an interface regression on the signing-and-publish path would reach a consumer before CI caught it.

## Change
- **`publish-app.yaml`**: add a backward-compatible `dry-run` input (boolean, default `false`) that gates the `publish` job with `if: ${{ !inputs.dry-run }}`. Default-`false` means real callers are unchanged.
- **`ci.yaml`**: add a `[Test] Publish App - Dry Run` job calling `publish-app.yaml` with `dry-run: true` (+ a placeholder `app-name`, which is a required input), and wire it into the `CI - Required Checks` `needs` list and aggregation.

This mirrors the established **`[Test] Publish .NET Library - Dry Run`** pattern exactly (its `publish` job is likewise `if: ${{ !inputs.dry-run }}`), so the dry-run job is skipped and aggregated as a pass — **no real GHCR push, no cosign signature**.

## Trade-off / scope
The issue floated a richer dry-run that *exercises* build + manifest packaging from a fixture. I deliberately chose the **interface-validation** shape that matches the sibling `publish-dotnet-library` test instead, because `publish-app.yaml` (a) hard-fails its `Require a v* tag` guard outside a tag ref (CI runs on `pull_request`), and (b) the digest-pin step requires a real `docker/build-push-action` digest output, which a `push: false` build does not reliably produce — making an in-PR build exercise fragile and prone to red CI. This change closes the stated completeness gap (every workflow now has a `[Test]` job) with a proven-green, consistent pattern. A deeper build-exercising fixture can be a follow-up if the maintainer wants it.

## Acceptance criteria
- [x] `ci.yaml` has a `publish-app` `[Test]` job, no real registry push / signature.
- [x] Aggregated by `CI - Required Checks`.
- [x] `actionlint`-clean (only the two pre-existing `code-quality`-scope warnings remain, unrelated to this diff); additive & backward-compatible.

## Validation
`actionlint 1.7.12` on both edited files: 0 new findings. Worktree-isolated; per-run worktree created + (about to be) removed.