### PR TITLE
docs: reconcile test-workflow convention with ci.yaml [Test]-job reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,14 +75,19 @@ there are no standalone `test-*.yaml` files. Every reusable workflow gets a job 
 it with safe parameters (dry-run, fixtures), and a single aggregation job gates the whole suite. When
 you add or change a reusable workflow, add or update its `[Test]` job in `ci.yaml`. Each job must:
 
-1. Use the job id `test-<workflow-name>` and the display name `[Test] <Workflow> - <Scenario>`
+1. Use a job id of `test-<workflow-name>`, adding a scenario suffix when a single workflow is exercised
+   by several jobs (e.g. `test-delete-workflow-runs-all`, `test-delete-workflow-runs-specific`,
+   `test-delete-workflow-runs-minimal`), plus a display name `[Test] <Workflow> - <Scenario>`
    (e.g. `test-publish-dotnet-library` → `[Test] Publish .NET Library - Dry Run`).
 2. Call the workflow under test with `uses: ./.github/workflows/<workflow-name>.yaml`.
 3. Pass safe parameters — set `dry-run: true` (or the workflow's equivalent) and use fixtures from
    `.github/fixtures/` when applicable. Never perform destructive operations.
-4. Be added to the `needs:` list of the `ci-required-checks` job (display name `CI - Required Checks`),
-   which runs `if: ${{ always() }}` and aggregates every `[Test]` job via the
-   `devantler-tech/actions/aggregate-job-checks` action — this is the single required status check.
+4. Wire the job into the `ci-required-checks` job (display name `CI - Required Checks`) in **two
+   places**: add it to the `needs:` list **and** add `${{ needs.<job-id>.result }}` to the
+   `job-results` input of that job's `devantler-tech/actions/aggregate-job-checks` step.
+   `ci-required-checks` runs `if: ${{ always() }}` and fails if any listed result is not `success`, so
+   it is the single required status check — a job added to `needs:` but omitted from `job-results`
+   would have its failure silently ignored.
 
 `ci.yaml` itself triggers on `pull_request` and `push`, with a `concurrency` group to prevent parallel
 runs. New reusable workflows that omit a `[Test]` job leave a coverage gap, so the job is part of the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,16 +68,25 @@ on:
   ##################################
 ```
 
-### Test Workflows
+### Test Jobs
 
-Test workflows exercise reusable workflows with safe parameters (dry-run, fixtures). They must:
+Reusable workflows are exercised as **`[Test]` jobs inside [`ci.yaml`](.github/workflows/ci.yaml)** —
+there are no standalone `test-*.yaml` files. Every reusable workflow gets a job in `ci.yaml` that calls
+it with safe parameters (dry-run, fixtures), and a single aggregation job gates the whole suite. When
+you add or change a reusable workflow, add or update its `[Test]` job in `ci.yaml`. Each job must:
 
-1. Be named `test-<workflow-name>.yaml`.
-2. Trigger on `pull_request` to `main` and `push` to `main`.
-3. Use `concurrency` groups to prevent parallel test runs.
-4. Include a status aggregation job with `if: ${{ !cancelled() }}`.
-5. Use test fixtures from `.github/fixtures/` when applicable.
-6. Never perform destructive operations — use dry-run modes or safe defaults.
+1. Use the job id `test-<workflow-name>` and the display name `[Test] <Workflow> - <Scenario>`
+   (e.g. `test-publish-dotnet-library` → `[Test] Publish .NET Library - Dry Run`).
+2. Call the workflow under test with `uses: ./.github/workflows/<workflow-name>.yaml`.
+3. Pass safe parameters — set `dry-run: true` (or the workflow's equivalent) and use fixtures from
+   `.github/fixtures/` when applicable. Never perform destructive operations.
+4. Be added to the `needs:` list of the `ci-required-checks` job (display name `CI - Required Checks`),
+   which runs `if: ${{ always() }}` and aggregates every `[Test]` job via the
+   `devantler-tech/actions/aggregate-job-checks` action — this is the single required status check.
+
+`ci.yaml` itself triggers on `pull_request` and `push`, with a `concurrency` group to prevent parallel
+runs. New reusable workflows that omit a `[Test]` job leave a coverage gap, so the job is part of the
+definition of done.
 
 ## Authentication Patterns
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of #252 (roadmap: complete · consistent · secure). **Fixes #255.**

## Problem
`AGENTS.md` → **Test Workflows** prescribed a convention the repo does not follow: standalone
`test-<workflow-name>.yaml` files triggered on `pull_request`/`push` to `main`. There are **no** such
files — every reusable workflow is exercised as a **`[Test]` job inside [`ci.yaml`](.github/workflows/ci.yaml)**
(e.g. `[Test] Publish .NET Library - Dry Run`), aggregated by the `CI - Required Checks` job. The split
appears carried over from the sibling `devantler-tech/actions` repo (where each action *does* have a
`test-*.yaml`). A contributor or agent following the doc literally would build the wrong structure.

## Change (docs only)
Rewrote the section as **Test Jobs**, describing what actually exists, verified against `ci.yaml`:
- Job id `test-<workflow-name>`, display name `[Test] <Workflow> - <Scenario>`.
- Each job `uses: ./.github/workflows/<workflow-name>.yaml` with safe params (`dry-run: true`, fixtures
  from `.github/fixtures/`); never destructive.
- Added to the `needs:` of the `ci-required-checks` job (`CI - Required Checks`), which runs
  `if: ${{ always() }}` and aggregates via `devantler-tech/actions/aggregate-job-checks` — the single
  required status check.
- `ci.yaml` triggers on `pull_request` + `push` with a `concurrency` group.
- Framed the `[Test]` job as part of the definition of done for any new reusable workflow.

## Acceptance criteria (from #255)
- [x] `AGENTS.md` *Test Workflows* matches how tests are actually structured.
- [x] No contradiction between the doc and `ci.yaml`.

## Validation
Docs-only; no workflow/code behaviour changes. No residual `test-*.yaml` references remain except the
sentence explaining their absence.