### PR TITLE
ci(security): add govulncheck supply-chain scanning to validate-go-project

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -284,6 +284,39 @@ jobs:
           fi
           echo "No dead code found ✅"
 
+  govulncheck:
+    name: 🛡️ Vulnerability Scan
+    runs-on: ubuntu-latest
+    needs: [changes]
+    # Skip if no Go files changed or on reusable-workflows repo; only on PRs
+    if: |
+      github.repository != 'devantler-tech/reusable-workflows'
+      && needs.changes.outputs.go == 'true'
+      && github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: 📥 Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+
+      # govulncheck reports only vulnerabilities your code actually CALLS (call-graph
+      # reachability), so it fails the gate (exit 3) only on genuinely exploitable issues
+      # — imported-but-unreachable vulnerabilities don't block. Fix by bumping the affected
+      # module or stopping the call.
+      - name: 🛡️ Scan for known vulnerabilities
+        run: govulncheck ./...
+
   lint:
     name: 🧹 Lint - mega-linter
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -296,6 +296,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ This file is the single canonical instructions file for the repository. It is re
     ├── scan-for-workflow-vulnerabilities.yaml # Reusable: Zizmor GitHub Actions security analysis
     ├── sync-cluster-policies.yaml         # Reusable: sync Kyverno policies from upstream
     ├── update-agent-skills.yaml           # Reusable: keep installed agent skills up-to-date
-    └── validate-go-project.yaml           # Reusable: Go lint, vuln-scan, build, test, coverage
+    └── validate-go-project.yaml           # Reusable: Go lint, tidy, build, test, coverage, dead-code & vuln scan
 ```
 
 > Dot-prefixed internal workflows (e.g. `.create-release.yaml`, `.sync-labels.yaml`) are this repo's own caller/maintenance workflows, not reusable `workflow_call` workflows, so they are intentionally omitted from the inventory above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ This file is the single canonical instructions file for the repository. It is re
     ├── scan-for-workflow-vulnerabilities.yaml # Reusable: Zizmor GitHub Actions security analysis
     ├── sync-cluster-policies.yaml         # Reusable: sync Kyverno policies from upstream
     ├── update-agent-skills.yaml           # Reusable: keep installed agent skills up-to-date
-    └── validate-go-project.yaml           # Reusable: Go lint, build, test, coverage
+    └── validate-go-project.yaml           # Reusable: Go lint, vuln-scan, build, test, coverage
 ```
 
 > Dot-prefixed internal workflows (e.g. `.create-release.yaml`, `.sync-labels.yaml`) are this repo's own caller/maintenance workflows, not reusable `workflow_call` workflows, so they are intentionally omitted from the inventory above.

--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
+- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block)
 - **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage).
 
 #### Usage


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #265.

## What

Adds a **`govulncheck` job** to the shared `validate-go-project.yaml` reusable workflow, so every devantler-tech Go consumer (go-template, ksail, …) inherits **supply-chain / known-vulnerability scanning** on each PR. Until now the workflow ran lint, dead-code, build, test, and coverage — but nothing checked dependencies against `vuln.go.dev`.

This closes the last gap flagged in the [go-template roadmap #75](https://github.com/devantler-tech/go-template/issues/75), which concluded `govulncheck` *"belongs on `reusable-workflows` … so every Go consumer inherits it."*

## How

- New `govulncheck` job mirrors the existing read-only `deadcode` job: `changes`-gated, `pull_request`-only, `permissions: { contents: read }`, sets up Go from `go.mod`.
- Installs `golang.org/x/vuln/cmd/govulncheck@v1.3.0` (pinned by version, same convention as `deadcode@v0.43.0`) and runs `govulncheck ./...`.
- README *Features* list + `AGENTS.md` inventory updated to name the step (docs in sync).

## Why it's safe to roll out

`govulncheck` uses **call-graph reachability** — it fails (exit 3) only on vulnerabilities the code actually *calls*; imported-but-unreachable advisories return exit 0 and **don't block**. Near-zero false positives.

Validated locally (govulncheck v1.3.0 / Go 1.26.3):

| Scenario | Result |
|---|---|
| Clean module | `No vulnerabilities found.` → **exit 0** (pass) |
| Reachable vuln (`jwt-go` `MapClaims.VerifyAudience`, GO-2020-0017) | `Your code is affected by 1 vulnerability` → **exit 3** (block) |
| Imported-but-unreachable vuln | `your code doesn't appear to call these` → **exit 0** (no false-block) |

`actionlint` + `yamllint` clean on the changed workflow (the only `actionlint` finding is the pre-existing `code-quality`-scope false positive on the unrelated `coverage` job, already ignored via mega-linter's `-ignore code-quality`). The workflow is unchanged on the `reusable-workflows` repo itself (all jobs skip here via the existing repo guard; the `[Test] Validate Go Project` job confirms it stays callable).

## Blast radius — flagged for the promotion decision

Additive but **impactful**: this is a **new required check on every Go consumer's PRs**. A consumer whose code reaches a known vulnerability will see this job fail until the affected module is bumped (or the call removed) — the intended supply-chain-security behavior. No consumer-side wiring change is needed (the called workflow fails as a unit). Shipping as a **draft**; promoting it is the deliberate decision to enable the gate across all Go repos.
