### PR TITLE
fix(release): ship workflow changes by releasing ci/build/refactor

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,16 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "ci", "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "refactor", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ See [README.md](README.md) for the full catalogue of reusable workflows with usa
 3. **Include `step-security/harden-runner`** as the first step of every job with `egress-policy: audit`.
 4. **Set `permissions: {}` at the workflow top level** — grant specific permissions per-job using job-level `permissions:`.
 5. **Set `persist-credentials: false`** on `actions/checkout` unless the job needs to push commits.
-6. **Use conventional commit messages** — `feat:`, `fix:`, `chore:`, `ci:` prefixes for semantic-release.
+6. **Use conventional commit messages** — semantic-release cuts releases from the commit type: `feat:` → minor; `fix:`, `perf:`, and the workflow-changing types `ci:`/`build:`/`refactor:` → patch (the reusable workflows *are* this repo's product, so changes to them must ship to consumers — see `.releaserc`'s `releaseRules`); `chore:`/`docs:`/`test:`/`style:` do not trigger a release.
 7. **Document secrets and inputs** in `README.md` with usage examples.
 
 ### Required Workflow Triggers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ See [README.md](README.md) for the full catalogue of reusable workflows with usa
 3. **Include `step-security/harden-runner`** as the first step of every job with `egress-policy: audit`.
 4. **Set `permissions: {}` at the workflow top level** — grant specific permissions per-job using job-level `permissions:`.
 5. **Set `persist-credentials: false`** on `actions/checkout` unless the job needs to push commits.
-6. **Use conventional commit messages** — semantic-release cuts releases from the commit type: `feat:` → minor; `fix:`, `perf:`, and the workflow-changing types `ci:`/`build:`/`refactor:` → patch (the reusable workflows *are* this repo's product, so changes to them must ship to consumers — see `.releaserc`'s `releaseRules`); `chore:`/`docs:`/`test:`/`style:` do not trigger a release.
+6. **Use conventional commit messages** — semantic-release cuts releases from the commit type: a breaking change (`feat!:`/`fix!:` or a `BREAKING CHANGE:` footer) → major; `feat:` → minor; `fix:`, `perf:`, `revert:`, and the workflow-changing types `ci:`/`build:`/`refactor:` → patch (the reusable workflows *are* this repo's product, so changes to them must ship to consumers — see `.releaserc`'s `releaseRules`); `chore:`/`docs:`/`test:`/`style:` do not trigger a release.
 7. **Document secrets and inputs** in `README.md` with usage examples.
 
 ### Required Workflow Triggers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ See [README.md](README.md) for the full catalogue of reusable workflows with usa
 3. **Include `step-security/harden-runner`** as the first step of every job with `egress-policy: audit`.
 4. **Set `permissions: {}` at the workflow top level** — grant specific permissions per-job using job-level `permissions:`.
 5. **Set `persist-credentials: false`** on `actions/checkout` unless the job needs to push commits.
-6. **Use conventional commit messages** — semantic-release cuts releases from the commit type: a breaking change (`feat!:`/`fix!:` or a `BREAKING CHANGE:` footer) → major; `feat:` → minor; `fix:`, `perf:`, `revert:`, and the workflow-changing types `ci:`/`build:`/`refactor:` → patch (the reusable workflows *are* this repo's product, so changes to them must ship to consumers — see `.releaserc`'s `releaseRules`); `chore:`/`docs:`/`test:`/`style:` do not trigger a release.
+6. **Use conventional commit messages** — semantic-release cuts releases from the commit type: a breaking change (a `!` after the type on **any** commit — e.g. `feat!:`, `fix!:`, `refactor!:`, `ci!:` — or a `BREAKING CHANGE:` footer) → major; `feat:` → minor; `fix:`, `perf:`, `revert:`, and the workflow-changing types `ci:`/`build:`/`refactor:` → patch (the reusable workflows *are* this repo's product, so changes to them must ship to consumers — see `.releaserc`'s `releaseRules`); `chore:`/`docs:`/`test:`/`style:` do not trigger a release.
 7. **Document secrets and inputs** in `README.md` with usage examples.
 
 ### Required Workflow Triggers


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

This repo's reusable workflows **are** its product, but the release config only ships a subset of the changes consumers depend on.

`.releaserc` uses `@semantic-release/commit-analyzer` with **default (angular) rules**, under which only `feat:` (minor) and `fix:`/`perf:` (patch) cut a release. Workflow-changing commit types — `ci:`, `build:`, `refactor:` — produce **no release**, so the change lands on `main` but is never tagged, and consumers pinned to a tag (e.g. `@v5.3.0`) never inherit it.

### Concrete evidence — govulncheck is stranded right now

[#266](https://github.com/devantler-tech/reusable-workflows/pull/266) (`ci(security): add govulncheck supply-chain scanning to validate-go-project`) was promoted and merged to `main` (`aead873`) **specifically to give every Go consumer supply-chain scanning**. But the `🎉 Create Release` run on that commit reported:

```
[@semantic-release/commit-analyzer] ℹ Analysis of 4 commits complete: no release
ℹ There are no relevant changes, so no new version is released.
```

No `v5.4.0` was cut — latest release is still `v5.3.0` (2026-05-29, pre-merge). So `validate-go-project.yaml`'s new `govulncheck` job exists on `main` but **no consumer will ever run it** (ksail pins `@v5.3.0`, go-template inherits the same way). The promoted PR's value is silently lost.

## Fix

Add `releaseRules` to `commit-analyzer` so the workflow-changing types trigger a **patch** release:

```jsonc
{ "type": "ci",       "release": "patch" }
{ "type": "build",    "release": "patch" }
{ "type": "refactor", "release": "patch" }
```

Custom `releaseRules` are evaluated **before** the defaults and are purely additive — `feat:`→minor, `fix:`/`perf:`→patch, `revert:`→patch all still apply, and `chore:`/`docs:`/`test:`/`style:` still correctly **don't** release. Rationale: in this repo, a `ci:`/`build:`/`refactor:` change *is* a change to the shipped product, so it must reach consumers; an occasional no-op patch (consumer renovate bumps the pin) is far cheaper than silently stranding a feature.

**Self-completing:** once merged, the next `Create Release` run analyses all commits since `v5.3.0` — including the stranded `ci(security)` govulncheck commit — and (with these rules) cuts the patch release that finally ships govulncheck. The PR title is `fix(...)` so the release fires regardless.

Also updates `AGENTS.md` rule 6 to document exactly which commit types release (was ambiguous — it listed `chore:`/`ci:` "for semantic-release" though neither released).

## Validation

- `.releaserc` is valid JSON (`python3 -m json.tool`).
- `releaseRules` semantics confirmed against semantic-release docs (custom rules first, then defaults; additive).
- Docs kept in sync in the same PR.

## Trade-offs / notes

- `ci:` also covers this repo's *own* meta-CI (e.g. `sync-labels`); those will now cut a harmless patch. Acceptable — under-releasing strands consumer-facing features (the bug above); over-releasing only adds a no-op tag.
- If the maintainer prefers `ci:` stay non-releasing and instead wants workflow changes authored as `feat:`/`fix:`, that's an alternative — but it relies on author discipline and wouldn't recover the already-merged govulncheck commit.