### PR TITLE
fix(validate-go): bound govulncheck memory so it stops OOM-killing the runner

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -295,6 +295,19 @@ jobs:
       && github.event_name == 'pull_request'
     permissions:
       contents: read
+    # govulncheck's default symbol scan builds a whole-program call graph in memory,
+    # whose peak grows with the module's dependency graph. On large modules (e.g. ones
+    # importing Kubernetes / Flux / Talos clients) it can exhaust the hosted runner's RAM,
+    # which the host resolves by killing the runner mid-scan (exit 143 / "runner has
+    # received a shutdown signal") — an opaque, retry-resistant failure. GOMEMLIMIT caps
+    # the Go runtime's heap so the GC reclaims aggressively and stays under the host
+    # ceiling instead of OOM-killing; timeout-minutes bounds the worst case to a clear,
+    # fast failure rather than a hung runner.
+    timeout-minutes: 15
+    env:
+      # ubuntu-latest provides 16 GiB RAM; leave headroom for the OS, the Go toolchain
+      # subprocesses and harden-runner.
+      GOMEMLIMIT: 12GiB
     steps:
       - name: 🛡️ Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #269

## Problem

The `🛡️ Vulnerability Scan` job (`govulncheck ./...`, added in #266) **kills the runner mid-scan** on large Go modules. govulncheck's default `-scan symbol` builds a whole-program call graph whose peak memory grows with the dependency graph; on a k8s-scale module (ksail imports Kubernetes/Flux/Talos/Omni clients) it exhausts the hosted runner's 16 GiB and the host terminates the runner — `exit 143` / *"The runner has received a shutdown signal"* / *"The operation was canceled"*, with **no govulncheck output**. It's an effective gate (org `code_quality` ruleset on consumers), so it blocks the PR, and **re-running just reproduces it**.

Two consecutive [ksail#4982](https://github.com/devantler-tech/ksail/pull/4982) runs both died ~2 min into the scan with zero output — see #269 for the run-by-run evidence. This regression (mine, from #266 ~5h ago) blocks **every large-repo Go PR**, not just ksail.

## Change

```diff
     permissions:
       contents: read
+    timeout-minutes: 15
+    env:
+      GOMEMLIMIT: 12GiB
```

- **`GOMEMLIMIT=12GiB`** — caps the Go runtime heap so the GC reclaims aggressively and stays under the host ceiling instead of OOM-killing. The standard Go remedy for CI OOMs. (ubuntu-latest = 16 GiB; 12 GiB leaves headroom for the OS, Go toolchain subprocesses and harden-runner.)
- **`timeout-minutes: 15`** — bounds any remaining worst case to a fast, legible failure instead of a hung runner.

**Reachability semantics are unchanged** — still `-scan symbol`, still exit-3-on-reachable-vuln only.

## Validation

- actionlint: no new findings on the diff (the only report is the pre-existing `code-quality: write` scope, unrelated to this change).
- `GOMEMLIMIT=12GiB` is valid Go syntax.
- Self-verifying once promoted: this PR's own CI won't run the job (it's `if: github.repository != 'devantler-tech/reusable-workflows'`), so the real proof is re-running ksail#4982's Vulnerability Scan against this branch's reusable workflow once it ships. I'll verify the rollout after merge.

## Trade-off / fallback (maintainer decision)

If a module's live call-graph genuinely exceeds the GOMEMLIMIT headroom, this converts the OOM into a clean timeout but the gate still can't pass. The robust fallback is switching the **gate** to `govulncheck -scan module ./...` (deterministic, low-memory; catches every known-vulnerable dependency *version*), at the cost of losing reachability filtering. That's a deliberate semantic change, so it's documented in #269 rather than applied here.