### PR TITLE
feat(validate-go): risk-acceptance allowlist for the govulncheck gate

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -329,11 +329,68 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       # govulncheck reports only vulnerabilities your code actually CALLS (call-graph
-      # reachability), so it fails the gate (exit 3) only on genuinely exploitable issues
-      # — imported-but-unreachable vulnerabilities don't block. Fix by bumping the affected
-      # module or stopping the call.
+      # reachability), so the gate trips only on genuinely reachable issues — imported-but-
+      # unreachable advisories never block. Normally you clear a finding by bumping the
+      # affected module or dropping the call. But some reachable advisories have NO upstream
+      # fix (`Fixed in: N/A`) — e.g. server-side symbols a CLI links transitively via
+      # k8s.io/kubernetes or docker/docker. A hard gate would then wedge EVERY Go PR on that
+      # consumer indefinitely, through no fault of the PR. To keep the gate strict by default
+      # yet allow explicit, reviewed, version-controlled risk acceptance, scan in JSON mode
+      # (which exits 0 on findings) and fail only on reachable findings whose advisory ID is
+      # NOT listed in an optional consumer-owned allowlist file.
+      #
+      # .govulncheck-allow.txt (repo root, OPTIONAL): one accepted advisory ID per line, e.g.
+      #   GO-2025-3547  # k8s apiserver race — this is a client CLI, not an apiserver (owner, 2026-06)
+      # blank lines and `#` comments are ignored. No file ⇒ strict (the original behaviour,
+      # unchanged): every reachable advisory blocks.
       - name: 🛡️ Scan for known vulnerabilities
-        run: govulncheck ./...
+        run: |
+          set -euo pipefail
+          # One scan only (expensive on large modules). JSON mode exits 0 even when
+          # vulnerabilities are found, so a non-zero exit here is an OPERATIONAL error
+          # (e.g. packages failed to load) and must fail the gate loudly.
+          rc=0
+          govulncheck -format json ./... > govuln.json || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::govulncheck failed to run (exit $rc) — operational error, not a scan result."
+            exit "$rc"
+          fi
+
+          # Reachable ("called") findings: a finding whose top trace frame is a function
+          # (mirrors govulncheck's own IsCalled: len(Trace)>0 && Trace[0].Function != "").
+          called="$(jq -r 'select(.finding).finding | select(.trace[0].function != null and .trace[0].function != "") | .osv' govuln.json | sort -u)"
+
+          # Optional allowlist of accepted, justified advisory IDs.
+          allow=""
+          if [ -f .govulncheck-allow.txt ]; then
+            allow="$(sed 's/#.*//' .govulncheck-allow.txt | tr -s ' \t' '\n' | grep -E '^GO-[0-9]{4}-[0-9]+$' | sort -u || true)"
+          fi
+
+          # Summarise every reachable advisory and compute the blocking set
+          # (reachable minus allowlisted).
+          blocking=""
+          if [ -n "$called" ]; then
+            echo "Reachable vulnerabilities:"
+            for id in $called; do
+              fixed="$(jq -r --arg id "$id" 'select(.finding).finding | select(.osv==$id) | .fixed_version // empty' govuln.json | grep -v '^$' | head -n1 || true)"
+              [ -z "$fixed" ] && fixed="N/A"
+              if printf '%s\n' "$allow" | grep -qx "$id"; then
+                echo "  - $id (fixed: $fixed) — ALLOWLISTED"
+              else
+                echo "  - $id (fixed: $fixed) — BLOCKING"
+                blocking="$blocking $id"
+              fi
+            done
+          else
+            echo "No reachable vulnerabilities found."
+          fi
+
+          if [ -n "$blocking" ]; then
+            echo "::error::Reachable vulnerabilities not accepted in .govulncheck-allow.txt:$blocking"
+            echo "Either bump the affected module (preferred) or, if no fix exists and the advisory is not exploitable in this project, add it to .govulncheck-allow.txt with a justification."
+            exit 1
+          fi
+          echo "✅ No blocking vulnerabilities (allowlisted advisories, if any, were explicitly accepted)."
 
   lint:
     name: 🧹 Lint - mega-linter

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
-- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block)
+- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block). A reachable advisory with no upstream fix (`Fixed in: N/A`) can be accepted explicitly by listing its ID in an optional `.govulncheck-allow.txt` at the repo root (one `GO-YYYY-NNNN  # justification` per line); the gate stays strict for everything else, and with no allowlist file behaves exactly as a plain `govulncheck ./...`
 - **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage).
 
 #### Usage


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Implements the mechanism proposed in #271.

## Problem

The `🛡️ Vulnerability Scan` gate added in #266 runs a hard `govulncheck ./...` and fails the PR on exit 3 (any *reachable* advisory). After the OOM fix (#270, released **v5.3.2**) the scan completes on large modules — and reveals the gate is **unsatisfiable** for a large consumer: govulncheck reports reachable vulnerabilities with **no upstream fix** (`Fixed in: N/A`), so no dependency bump can clear them. The gate then blocks **every** Go PR on that consumer, and will do so on *any* repo the moment a new advisory lands for a reachable-but-unpatched symbol.

Reproduced locally against ksail `main` (go 1.26.3): `GOMEMLIMIT=12GiB govulncheck ./...` completes (577s / 12.4 GB) but exits 3 on 4 advisories — `GO-2026-4887`, `GO-2026-4883` (docker/docker, Moby daemon-side), `GO-2025-3547`, `GO-2025-3521` (k8s.io/kubernetes, apiserver-side) — all `Fixed: N/A`, all reached only via package-init / generic-poll utility chains (ksail is a *client* CLI, not the Moby daemon or a kube-apiserver).

## Change

Run govulncheck in **JSON mode** (which exits 0 on findings) and fail only on reachable findings whose advisory ID is **not** listed in an optional, consumer-owned `.govulncheck-allow.txt` at the repo root:

```
GO-2025-3547  # k8s apiserver race — this is a client CLI, not an apiserver (owner, 2026-06)
```

- **No allowlist file ⇒ strict, unchanged** — every reachable advisory blocks, exactly as a plain `govulncheck ./...`.
- Risk acceptance is **explicit, justified, reviewed, and version-controlled** (the standard pattern for govulncheck-in-CI; govulncheck v1.3.0 has no native suppression).
- "Reachable" is determined the same way govulncheck does (`len(Trace)>0 && Trace[0].Function != ""`), so imported-but-unreachable advisories still never count.
- A **non-zero** govulncheck exit in JSON mode is treated as an operational error (e.g. packages failed to load) and fails the gate loudly — it never silently passes.
- Still **one scan** (the expensive part is unchanged); only the gating/reporting around it changed. Keeps `GOMEMLIMIT`/`timeout-minutes` from #270.

## Validation

- **Gating logic unit-tested locally** against synthetic govulncheck JSON across 4 cases: vulns + no allowlist → blocks all (≡ today); vulns + full allowlist → passes; vulns + partial allowlist → blocks only the non-allowlisted; clean scan → passes. Imported-but-unreachable advisory correctly never counted.
- `actionlint`: **no new findings** (only the pre-existing `code-quality` permission-scope false-positive, present on `main`); embedded `shellcheck` clean on the new step.
- This workflow's vuln job `if: github.repository != 'devantler-tech/reusable-workflows'`, so rw's own CI can't exercise it — the local unit tests above stand in.

## Policy (maintainer's call — separate from this mechanism)

This PR is the **mechanism** only; default behaviour is unchanged. *Whether* to accept the four ksail advisories above (and with what justification) is a security-policy decision for a follow-up `.govulncheck-allow.txt` in the ksail repo.

## Links

- Fixes #271 · follows #266 (gate) and #269/#270 (OOM fix, v5.3.2)
- **Unblocks** [ksail#4982](https://github.com/devantler-tech/ksail/pull/4982) and [ksail#4984](https://github.com/devantler-tech/ksail/pull/4984) once this lands and ksail adds its allowlist.
