### PR TITLE
refactor(validate-go): use the official golang/govulncheck-action

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -319,78 +319,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: ⚙️ Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: 📥 Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-
       # govulncheck reports only vulnerabilities your code actually CALLS (call-graph
-      # reachability), so the gate trips only on genuinely reachable issues — imported-but-
-      # unreachable advisories never block. Normally you clear a finding by bumping the
-      # affected module or dropping the call. But some reachable advisories have NO upstream
-      # fix (`Fixed in: N/A`) — e.g. server-side symbols a CLI links transitively via
-      # k8s.io/kubernetes or docker/docker. A hard gate would then wedge EVERY Go PR on that
-      # consumer indefinitely, through no fault of the PR. To keep the gate strict by default
-      # yet allow explicit, reviewed, version-controlled risk acceptance, scan in JSON mode
-      # (which exits 0 on findings) and fail only on reachable findings whose advisory ID is
-      # NOT listed in an optional consumer-owned allowlist file.
-      #
-      # .govulncheck-allow.txt (repo root, OPTIONAL): one accepted advisory ID per line, e.g.
-      #   GO-2025-3547  # k8s apiserver race — this is a client CLI, not an apiserver (owner, 2026-06)
-      # blank lines and `#` comments are ignored. No file ⇒ strict (the original behaviour,
-      # unchanged): every reachable advisory blocks.
+      # reachability), so the gate trips only on genuinely reachable issues —
+      # imported-but-unreachable advisories never block. The official action sets up Go
+      # from go.mod, installs govulncheck, runs `govulncheck ./...`, and fails the job on
+      # any reachable finding. (We check out above with persist-credentials:false, so the
+      # action's own checkout is disabled via repo-checkout:false.)
       - name: 🛡️ Scan for known vulnerabilities
-        run: |
-          set -euo pipefail
-          # One scan only (expensive on large modules). JSON mode exits 0 even when
-          # vulnerabilities are found, so a non-zero exit here is an OPERATIONAL error
-          # (e.g. packages failed to load) and must fail the gate loudly.
-          rc=0
-          govulncheck -format json ./... > govuln.json || rc=$?
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::govulncheck failed to run (exit $rc) — operational error, not a scan result."
-            exit "$rc"
-          fi
-
-          # Reachable ("called") findings: a finding whose top trace frame is a function
-          # (mirrors govulncheck's own IsCalled: len(Trace)>0 && Trace[0].Function != "").
-          called="$(jq -r 'select(.finding).finding | select(.trace[0].function != null and .trace[0].function != "") | .osv' govuln.json | sort -u)"
-
-          # Optional allowlist of accepted, justified advisory IDs.
-          allow=""
-          if [ -f .govulncheck-allow.txt ]; then
-            allow="$(sed 's/#.*//' .govulncheck-allow.txt | tr -s ' \t' '\n' | grep -E '^GO-[0-9]{4}-[0-9]+$' | sort -u || true)"
-          fi
-
-          # Summarise every reachable advisory and compute the blocking set
-          # (reachable minus allowlisted).
-          blocking=""
-          if [ -n "$called" ]; then
-            echo "Reachable vulnerabilities:"
-            for id in $called; do
-              fixed="$(jq -r --arg id "$id" 'select(.finding).finding | select(.osv==$id) | .fixed_version // empty' govuln.json | grep -v '^$' | head -n1 || true)"
-              [ -z "$fixed" ] && fixed="N/A"
-              if printf '%s\n' "$allow" | grep -qx "$id"; then
-                echo "  - $id (fixed: $fixed) — ALLOWLISTED"
-              else
-                echo "  - $id (fixed: $fixed) — BLOCKING"
-                blocking="$blocking $id"
-              fi
-            done
-          else
-            echo "No reachable vulnerabilities found."
-          fi
-
-          if [ -n "$blocking" ]; then
-            echo "::error::Reachable vulnerabilities not accepted in .govulncheck-allow.txt:$blocking"
-            echo "Either bump the affected module (preferred) or, if no fix exists and the advisory is not exploitable in this project, add it to .govulncheck-allow.txt with a justification."
-            exit 1
-          fi
-          echo "✅ No blocking vulnerabilities (allowlisted advisories, if any, were explicitly accepted)."
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          repo-checkout: false
+          go-version-file: go.mod
 
   lint:
     name: 🧹 Lint - mega-linter

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
-- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block). A reachable advisory with no upstream fix (`Fixed in: N/A`) can be accepted explicitly by listing its ID in an optional `.govulncheck-allow.txt` at the repo root (one `GO-YYYY-NNNN  # justification` per line); the gate stays strict for everything else, and with no allowlist file behaves exactly as a plain `govulncheck ./...`
+- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) via the official [`golang/govulncheck-action`](https://github.com/golang/govulncheck-action) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block).
 - **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage).
 
 #### Usage


### PR DESCRIPTION
Migrates the Go vulnerability gate from a hand-rolled implementation to the official action, per maintainer direction.

## What

Replaces the custom `govulncheck` step in `validate-go-project.yaml` with the official [`golang/govulncheck-action@v1.0.4`](https://github.com/golang/govulncheck-action) (pinned by SHA `b625fbe`).

- **Before:** `actions/setup-go` + `go install golang.org/x/vuln/cmd/govulncheck@v1.3.0` + a ~60-line custom JSON-mode scan with a `.govulncheck-allow.txt` allowlist.
- **After:** the official action sets up Go from `go.mod`, installs govulncheck, and runs `govulncheck ./...` in default (text) mode — failing the job on any reachable finding. **Same call-graph-reachability gate, ~71 fewer lines.**

**Kept unchanged:** `harden-runner`, the hardened checkout (`persist-credentials: false`; the action's own checkout is disabled via `repo-checkout: false`), and the job-level `GOMEMLIMIT: 12GiB` + `timeout-minutes: 15` (the scan still builds a whole-program call graph, so the OOM tuning still applies).

## Trade-off (intentional)

This **drops the `.govulncheck-allow.txt` risk-acceptance allowlist** — the official action has no equivalent. No repo currently ships an allowlist file, so there is **no behavior change for any current consumer**. If a reachable advisory with no upstream fix (`Fixed in: N/A`) ever appears (e.g. a server-side symbol linked transitively via `k8s.io/kubernetes`), the gate will block with no in-workflow override; the recourse is then to bump the dep, drop the call, or re-introduce a gating shim. Chosen deliberately in favor of the simpler, official integration.

> Note: the official action installs `govulncheck@latest` (vs. the previous pinned `@v1.3.0`); the action itself is SHA-pinned. Floating-latest is generally desirable for a vuln scanner (newest detection + advisory DB).

## Scope

`govulncheck` is implemented **only here** — there is no custom govulncheck action in `devantler-tech/actions`, and consumers (e.g. `ksail`) don't reimplement it; they inherit this gate by calling `validate-go-project.yaml@<tag>`. So this single workflow change **is** the whole migration. Consumers pick it up automatically on the next release + their routine version bump — no per-consumer edit needed.

## Validation

- `actionlint` (with the CI's `-ignore code-quality`) and `yamllint`: pass.
- Inputs match the action's documented interface (`repo-checkout`, `go-version-file`).
- `ci.yaml`'s `[Test] Validate Go Project` job only checks the workflow is *callable* (every internal job self-skips on this repo via the `github.repository != ...` guard); the gate runs end-to-end on consumers post-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
