### PR TITLE
ci(security): add harden-runner (egress audit) to every job

### DIFF
--- a/.github/workflows/.sync-labels.yaml
+++ b/.github/workflows/.sync-labels.yaml
@@ -14,6 +14,11 @@ jobs:
     name: Run EndBug/label-sync
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,6 +164,11 @@ jobs:
     permissions: {}
     if: ${{ always() }}
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📊 Require all CI checks to pass
         uses: devantler-tech/actions/aggregate-job-checks@59d3ffbe1a9437fcc39e2794fa2f221abe878310 # v3.3.0
         with:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -18,6 +18,11 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🔑 Get GitHub App Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token

--- a/.github/workflows/delete-workflow-runs.yaml
+++ b/.github/workflows/delete-workflow-runs.yaml
@@ -53,6 +53,11 @@ jobs:
       actions: write
       contents: read
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🗑️ Delete workflow runs
         uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee # v2.1.0
         with:

--- a/.github/workflows/deploy-github-pages.yaml
+++ b/.github/workflows/deploy-github-pages.yaml
@@ -44,6 +44,11 @@ jobs:
       pages: write
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -83,6 +88,11 @@ jobs:
     outputs:
       page-url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -23,6 +23,11 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
 
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🔑 Generate GitHub App Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token

--- a/.github/workflows/publish-dotnet-library.yaml
+++ b/.github/workflows/publish-dotnet-library.yaml
@@ -22,6 +22,11 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/run-dotnet-tests.yaml
+++ b/.github/workflows/run-dotnet-tests.yaml
@@ -27,6 +27,11 @@ jobs:
     # Ignore Require Workflow runs
     if: github.repository != 'devantler-tech/reusable-workflows'
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/scan-for-todo-comments.yaml
+++ b/.github/workflows/scan-for-todo-comments.yaml
@@ -22,6 +22,11 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/scan-for-workflow-vulnerabilities.yaml
+++ b/.github/workflows/scan-for-workflow-vulnerabilities.yaml
@@ -18,6 +18,11 @@ jobs:
       contents: read # only needed for private repos
       actions: read # only needed for private repos
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -28,6 +28,11 @@ jobs:
       KYVERNO_POLICIES_TEMP_DIR: /tmp/cluster-policies
 
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Generate GitHub App Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token

--- a/.github/workflows/update-agent-skills.yaml
+++ b/.github/workflows/update-agent-skills.yaml
@@ -71,6 +71,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🔑 Generate GitHub App token
         id: app-token
         if: ${{ inputs.use-app-token }}

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -39,6 +39,11 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       lintable: ${{ steps.filter.outputs.lintable }}
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -125,6 +130,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🔑 Generate GitHub App Token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -188,6 +198,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🔑 Generate GitHub App Token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -256,6 +271,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📄 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -297,6 +317,11 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🔑 Generate GitHub App Token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -372,6 +397,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -397,6 +427,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -426,6 +461,11 @@ jobs:
       # must also grant this (a reusable workflow's token is capped by the caller's grant).
       code-quality: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 📑 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #267 — **Option A** (apply the rule, harden the library).

## What

`AGENTS.md` (Reusable Workflow Conventions, rule 3) requires `step-security/harden-runner` as the **first step of every job** with `egress-policy: audit`, but only `publish-app.yaml` actually had it (1 of 14 at audit time). This reconciles the doc-vs-reality drift by adding the canonical hardened step to **all 21 remaining jobs that run steps**, across 13 workflows.

## Why Option A

Per the issue, both options close the gap; I took **A** (the issue's own lean) because it's the most defensible read of the current `AGENTS.md` wording, is **low-risk and backward-compatible** (audit mode only records egress — it never blocks), and gives every consumer egress telemetry. No `AGENTS.md` change is needed — the rule already says this; reality now matches it.

## Scope notes

- **Reusable-call jobs are intentionally skipped.** `uses:`-style caller jobs (e.g. all the `test-*` jobs in `ci.yaml`, the `release` job in `.create-release.yaml`) can't carry steps — harden-runner lives inside the *called* workflow, so those are correctly untouched.
- **`.sync-labels.yaml` is included** even though the original audit table omitted it — its `sync` job runs steps and was missing the rule. (`template-sync.yaml` from the audit table has since been removed upstream, so it's no longer in scope.)
- Pinned to the same SHA already used in `publish-app.yaml`: `step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4`.

## Validation

- `actionlint` clean on the change — the only findings are **pre-existing** `code-quality` permission-scope warnings (from the Code Quality coverage migration; actionlint's version doesn't yet know that real GitHub scope) and are present on `main` unchanged.
- Purely additive: 13 files, +105 lines (21 jobs × 5), no behavior change.

## Acceptance criteria (from #267)

- [x] `AGENTS.md` and the workflows agree — every step-running job now has harden-runner (Option A).
- [x] `actionlint`-clean; one focused PR; no behavior change (audit mode).