### PR TITLE
fix(validate-go): restore the govulncheck risk-acceptance allowlist

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -339,17 +339,78 @@ jobs:
         with:
           persist-credentials: false
 
-      # govulncheck reports only vulnerabilities your code actually CALLS (call-graph
-      # reachability), so the gate trips only on genuinely reachable issues —
-      # imported-but-unreachable advisories never block. The official action sets up Go
-      # from go.mod, installs govulncheck, runs `govulncheck ./...`, and fails the job on
-      # any reachable finding. (We check out above with persist-credentials:false, so the
-      # action's own checkout is disabled via repo-checkout:false.)
-      - name: 🛡️ Scan for known vulnerabilities
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          repo-checkout: false
           go-version-file: go.mod
+          cache: true
+
+      - name: 📥 Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+
+      # govulncheck reports only vulnerabilities your code actually CALLS (call-graph
+      # reachability), so the gate trips only on genuinely reachable issues — imported-but-
+      # unreachable advisories never block. Normally you clear a finding by bumping the
+      # affected module or dropping the call. But some reachable advisories have NO upstream
+      # fix (`Fixed in: N/A`) — e.g. server-side symbols a CLI links transitively via
+      # k8s.io/kubernetes or docker/docker. A hard gate would then wedge EVERY Go PR on that
+      # consumer indefinitely, through no fault of the PR. To keep the gate strict by default
+      # yet allow explicit, reviewed, version-controlled risk acceptance, scan in JSON mode
+      # (which exits 0 on findings) and fail only on reachable findings whose advisory ID is
+      # NOT listed in an optional consumer-owned allowlist file.
+      #
+      # .govulncheck-allow.txt (repo root, OPTIONAL): one accepted advisory ID per line, e.g.
+      #   GO-2025-3547  # k8s apiserver race — this is a client CLI, not an apiserver (owner, 2026-06)
+      # blank lines and `#` comments are ignored. No file ⇒ strict (the original behaviour,
+      # unchanged): every reachable advisory blocks.
+      - name: 🛡️ Scan for known vulnerabilities
+        run: |
+          set -euo pipefail
+          # One scan only (expensive on large modules). JSON mode exits 0 even when
+          # vulnerabilities are found, so a non-zero exit here is an OPERATIONAL error
+          # (e.g. packages failed to load) and must fail the gate loudly.
+          rc=0
+          govulncheck -format json ./... > govuln.json || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::govulncheck failed to run (exit $rc) — operational error, not a scan result."
+            exit "$rc"
+          fi
+
+          # Reachable ("called") findings: a finding whose top trace frame is a function
+          # (mirrors govulncheck's own IsCalled: len(Trace)>0 && Trace[0].Function != "").
+          called="$(jq -r 'select(.finding).finding | select(.trace[0].function != null and .trace[0].function != "") | .osv' govuln.json | sort -u)"
+
+          # Optional allowlist of accepted, justified advisory IDs.
+          allow=""
+          if [ -f .govulncheck-allow.txt ]; then
+            allow="$(sed 's/#.*//' .govulncheck-allow.txt | tr -s ' \t' '\n' | grep -E '^GO-[0-9]{4}-[0-9]+$' | sort -u || true)"
+          fi
+
+          # Summarise every reachable advisory and compute the blocking set
+          # (reachable minus allowlisted).
+          blocking=""
+          if [ -n "$called" ]; then
+            echo "Reachable vulnerabilities:"
+            for id in $called; do
+              fixed="$(jq -r --arg id "$id" 'select(.finding).finding | select(.osv==$id) | .fixed_version // empty' govuln.json | grep -v '^$' | head -n1 || true)"
+              [ -z "$fixed" ] && fixed="N/A"
+              if printf '%s\n' "$allow" | grep -qx "$id"; then
+                echo "  - $id (fixed: $fixed) — ALLOWLISTED"
+              else
+                echo "  - $id (fixed: $fixed) — BLOCKING"
+                blocking="$blocking $id"
+              fi
+            done
+          else
+            echo "No reachable vulnerabilities found."
+          fi
+
+          if [ -n "$blocking" ]; then
+            echo "::error::Reachable vulnerabilities not accepted in .govulncheck-allow.txt:$blocking"
+            echo "Either bump the affected module (preferred) or, if no fix exists and the advisory is not exploitable in this project, add it to .govulncheck-allow.txt with a justification."
+            exit 1
+          fi
+          echo "✅ No blocking vulnerabilities (allowlisted advisories, if any, were explicitly accepted)."
 
   lint:
     name: 🧹 Lint - mega-linter

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
-- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) via the official [`golang/govulncheck-action`](https://github.com/golang/govulncheck-action) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block).
+- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block). A reachable advisory with no upstream fix (`Fixed in: N/A`) can be accepted explicitly by listing its ID in an optional `.govulncheck-allow.txt` at the repo root (one `GO-YYYY-NNNN  # justification` per line); the gate stays strict for everything else, and with no allowlist file behaves exactly as a plain `govulncheck ./...`
 - **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage).
 
 #### Usage


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — the ksail Go PR lane is wedged with no recourse

A newly-published advisory **GO-2026-4887** (Moby/`github.com/docker/docker`, *AuthZ plugin bypass*, **Fixed in: N/A**) is **reachable** from ksail (it links the Docker client transitively) and now **fails the `🛡️ Vulnerability Scan` job on every ksail Go PR** — e.g. my own promoted [ksail#4986](https://github.com/devantler-tech/ksail/pull/4986), which is otherwise green. Because the scan is `pull_request`-only it never runs on `main`, so `main` shows green while the entire PR lane is blocked. There is **no available recourse**: the documented fix ("bump the affected module") can't apply to an advisory with no upstream fix.

## Root cause — #273 silently dropped the #272 allowlist

- [#272](https://github.com/devantler-tech/reusable-workflows/pull/272) *added* a risk-acceptance allowlist (`.govulncheck-allow.txt`): scan in JSON mode, fail only on reachable advisories **not** explicitly accepted.
- [#273](https://github.com/devantler-tech/reusable-workflows/pull/273) ("refactor: use the official `golang/govulncheck-action`", *per maintainer direction*) replaced that with the official action, which **has no allowlist equivalent** and fails on any reachable finding.

#273's stated premise was **"No repo currently ships an allowlist file, so there is no behavior change"** — but that was **already false at merge time**: ksail merged [`.govulncheck-allow.txt` (ksail#4985)](https://github.com/devantler-tech/ksail/pull/4985) at ~18:10Z on 2026-06-01, **before** #273 merged at ~21:45Z. ksail has been shipping a now-inert allowlist ever since, and the precise "Fixed in: N/A reachable advisory" scenario #273 itself flagged as the known risk has now occurred.

## Fix

Restore #272's JSON-mode scan that honours an optional consumer-owned `.govulncheck-allow.txt`:
- **Strict by default** — no allowlist file ⇒ behaves exactly like a plain `govulncheck ./...` (every reachable advisory blocks). No behaviour change for repos without the file.
- A **reachable advisory with no upstream fix** can be explicitly, reviewably, version-controlled risk-accepted (one `GO-YYYY-NNNN  # justification` per line).
- Unreachable / imported-but-not-called advisories never block (unchanged call-graph semantics).
- **Untouched:** `harden-runner` (egress audit), the hardened checkout (`persist-credentials: false`), and the `GOMEMLIMIT: 12GiB` + `timeout-minutes: 15` OOM tuning from #270/#274.

## Validation

- `actionlint` clean on the changed job (the one remaining finding — `code-quality` permission scope — is pre-existing in an unrelated job and is a known actionlint gap, not introduced here).
- YAML parses.
- Shell + `jq` logic functionally tested **under bash** (the real `run:` shell) across three scenarios: (A) a reachable, non-allowlisted advisory → **FAIL**; (B) all reachable advisories allowlisted, an unreachable one present → **PASS**; (C) no allowlist file → strict **FAIL** on all reachable. All behaved as designed.

## Trade-off — this reverses a maintainer-directed decision

#273 was explicitly maintainer-directed, so this is surfaced as a **draft for your call**, not a unilateral change:
- **Promote** ⇒ accept restoring the allowlist (unwedges ksail and any future Fixed-in-N/A case); I'll then drive it to merge.
- **Close** ⇒ keep the official action and resolve the ksail block another way.

**Propagation note:** the PR-time `🛡️ Vulnerability Scan` is the **org-wide required workflow**, which runs `validate-go-project.yaml` at the org-configured ref (currently past `v5.4.0`). For this fix to actually unblock ksail PRs, that ref (and/or a new reusable-workflows release) must point at the merged commit — a maintainer/release step outside this repo.

Relates to ksail#4986 (blocked), ksail#4985 (`.govulncheck-allow.txt`), #272, #273.