### PR TITLE
ci(validate-go): restore reachable-advisory allowlist via govulncheck-action fork

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -346,19 +346,38 @@ jobs:
       # reachable finding. (We check out above with persist-credentials:false, so the
       # action's own checkout is disabled via repo-checkout:false.)
       #
-      # `allow-file` lets a consumer risk-accept a reachable advisory that has NO upstream
-      # fix (`Fixed in: N/A`) — e.g. a server-side symbol a CLI links transitively via
-      # k8s.io/kubernetes or docker/docker — with an explicit, version-controlled
-      # justification, instead of wedging EVERY Go PR on that consumer indefinitely. The
-      # gate stays strict by default: a consumer with no `.govulncheck-allow.txt` blocks on
-      # any reachable advisory, exactly as before. See the consumer-repo file format in the
-      # action README.
-      #
-      # The official golang/govulncheck-action has no allowlist input, so this temporarily
-      # uses a devantler fork carrying the `allow-file` feature. Swap back to
-      # golang/govulncheck-action once the upstream change lands (golang/go feature request
-      # filed; fork branch: devantler/govulncheck-action@feat/allow-file).
+      # Most consumers have no `.govulncheck-allow.txt` and keep using the **official**
+      # `golang/govulncheck-action` unchanged (the step below) — a strict gate that blocks on
+      # any reachable advisory. Only a consumer that opts in by committing a
+      # `.govulncheck-allow.txt` takes the fork path, which adds an `allow-file` input so it
+      # can risk-accept a reachable advisory that has NO upstream fix (`Fixed in: N/A`) —
+      # e.g. a server-side symbol a CLI links transitively via k8s.io/kubernetes or
+      # docker/docker — with an explicit, version-controlled justification, instead of
+      # wedging EVERY Go PR on that consumer indefinitely. Splitting on the file's presence
+      # keeps the official action on the path for every repo except opt-in ones, minimising
+      # the fork's blast radius. The official action has no allowlist input, so the opt-in
+      # path uses a thin devantler fork carrying the `allow-file` feature; swap it back to
+      # `golang/govulncheck-action` once the feature is upstreamed (the fork is Gerrit-ready
+      # at devantler/govulncheck-action@feat/allow-file). See the action README for the file
+      # format.
+      - name: 🔎 Detect govulncheck allowlist
+        id: govulncheck-allow
+        run: |
+          if [ -f .govulncheck-allow.txt ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 🛡️ Scan for known vulnerabilities
+        if: steps.govulncheck-allow.outputs.present == 'false'
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          repo-checkout: false
+          go-version-file: go.mod
+
+      - name: 🛡️ Scan for known vulnerabilities (with risk-acceptance allowlist)
+        if: steps.govulncheck-allow.outputs.present == 'true'
         uses: devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942 # feat/allow-file (fork; pending upstream)
         with:
           repo-checkout: false

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -341,15 +341,29 @@ jobs:
 
       # govulncheck reports only vulnerabilities your code actually CALLS (call-graph
       # reachability), so the gate trips only on genuinely reachable issues —
-      # imported-but-unreachable advisories never block. The official action sets up Go
-      # from go.mod, installs govulncheck, runs `govulncheck ./...`, and fails the job on
-      # any reachable finding. (We check out above with persist-credentials:false, so the
+      # imported-but-unreachable advisories never block. The action sets up Go from
+      # go.mod, installs govulncheck, runs `govulncheck ./...`, and fails the job on any
+      # reachable finding. (We check out above with persist-credentials:false, so the
       # action's own checkout is disabled via repo-checkout:false.)
+      #
+      # `allow-file` lets a consumer risk-accept a reachable advisory that has NO upstream
+      # fix (`Fixed in: N/A`) — e.g. a server-side symbol a CLI links transitively via
+      # k8s.io/kubernetes or docker/docker — with an explicit, version-controlled
+      # justification, instead of wedging EVERY Go PR on that consumer indefinitely. The
+      # gate stays strict by default: a consumer with no `.govulncheck-allow.txt` blocks on
+      # any reachable advisory, exactly as before. See the consumer-repo file format in the
+      # action README.
+      #
+      # The official golang/govulncheck-action has no allowlist input, so this temporarily
+      # uses a devantler fork carrying the `allow-file` feature. Swap back to
+      # golang/govulncheck-action once the upstream change lands (golang/go feature request
+      # filed; fork branch: devantler/govulncheck-action@feat/allow-file).
       - name: 🛡️ Scan for known vulnerabilities
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        uses: devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942 # feat/allow-file (fork; pending upstream)
         with:
           repo-checkout: false
           go-version-file: go.mod
+          allow-file: .govulncheck-allow.txt
 
   lint:
     name: 🧹 Lint - mega-linter

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ The workflow assumes skills were previously installed with [`devantler-tech/acti
 - **Automated Linting**: Runs `golangci-lint` and `mega-linter` to ensure code quality
 - **Auto-fix**: Automatically applies linter fixes and commits them
 - **Copilot Integration**: When linting fails, automatically prompts Copilot on the PR to fix the remaining issues
-- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) via the official [`golang/govulncheck-action`](https://github.com/golang/govulncheck-action) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block).
+- **Supply-chain Scanning**: Runs [`govulncheck`](https://go.dev/blog/govulncheck) via the official [`golang/govulncheck-action`](https://github.com/golang/govulncheck-action) to fail the PR on known vulnerabilities your code actually calls (call-graph reachability, so imported-but-unreachable advisories don't block). A consumer can risk-accept a reachable advisory that has no upstream fix (`Fixed in: N/A`) by committing an optional `.govulncheck-allow.txt` at the repo root (one `GO-YYYY-NNNN  # justification` per line; `#` comments and blank lines ignored); the gate stays strict for everything else. Repos with no allowlist file keep using the official action unchanged — only opt-in repos take the allowlist-aware path.
 - **Code Coverage**: Generates a Cobertura report and uploads it to **GitHub Code Quality** (native PR coverage).
 
 #### Usage


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `🛡️ Vulnerability Scan` job is the **org-wide required workflow** (org ruleset *"Require workflows to pass before merging for Go"*, `id 10320335`), which pins this file at **`refs/heads/main`** and runs it on every Go PR org-wide. Since #273 moved the scan to the official `golang/govulncheck-action`, the gate fails on **any** reachable advisory with **no in-workflow override**.

That wedges every Go PR on a consumer that links a reachable advisory with **no upstream fix** (`Fixed in: N/A`) — e.g. `ksail`, which links server-side `k8s.io/kubernetes` / `docker/docker` symbols transitively. ksail shipped a `.govulncheck-allow.txt` (risk-accepting 4 such advisories) expecting the v5.4.0 allowlist gate, but that logic was removed in #273, so the file is read by nothing and every ksail Go PR shows a red vuln scan.

## What this does

Splits the scan on whether the consumer commits a `.govulncheck-allow.txt`:

- **No allowlist file ⇒ official action, unchanged.** A detect step sets `present=false` and the scan runs the **official** `golang/govulncheck-action` exactly as today — a strict gate that blocks on any reachable advisory. **This is the path for every consumer except opt-in ones**, so the fork never touches the vast majority of Go repos (minimal blast radius — addresses the reviewer's supply-chain concern).
- **Allowlist file present ⇒ opt-in fork path.** Only a repo that ships `.govulncheck-allow.txt` (one accepted `GO-YYYY-NNNN` per line; `#` comments + blanks ignored) takes the **`devantler/govulncheck-action@feat/allow-file`** fork, which adds an `allow-file` input and fails only on reachable advisories **not** listed.

## Blast radius

This file is the org-wide Go gate (ruleset tracks `main`), so merging applies to **all** Go consumers immediately. Safe because the default (no-allowlist) path is the **official action, byte-for-byte the same strict gate**; only repos that *add* an allowlist file change behavior and reach the fork.

## Validation

- `actionlint -ignore code-quality` on this file: clean (the `code-quality` scope is the pre-existing false positive CI already ignores).
- Fork feature (`action.yml` +69/-2) unit-tested under `bash`: allowlisted → excused, non-allowlisted reachable → blocks, strict/no-file → blocks all, all-allowlisted → passes.
- README updated to document the opt-in `.govulncheck-allow.txt`.

## Follow-ups

1. **Upstream (maintainer-side).** `golang/govulncheck-action` is a Gerrit-backed Go-project mirror — contributions go through [go-review.googlesource.com](https://go-review.googlesource.com) and require a signed **Google CLA**, so this can't be filed via a GitHub PR autonomously. The fork is Gerrit-ready at **`devantler/govulncheck-action@feat/allow-file`**; once `allow-file` lands upstream, swap the opt-in `uses:` back to `golang/govulncheck-action@<sha>` and delete the fork.
2. After this merges, ksail's `🛡️ Vulnerability Scan` goes green and unblocks #4986 / #4945 / #4905. It must **not** be added to ksail's required-checks gate until then, or it wedges all Go PRs.

Supersedes #275 (which re-implemented the scan as an in-workflow shim — *"our own solution"* — and was closed per maintainer review in favor of this official-action-preserving approach).