### PR TITLE
fix(validate-go-project): use SHA-pinned govulncheck fork on all paths

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -346,20 +346,25 @@ jobs:
       # reachable finding. (We check out above with persist-credentials:false, so the
       # action's own checkout is disabled via repo-checkout:false.)
       #
-      # Most consumers have no `.govulncheck-allow.txt` and keep using the **official**
-      # `golang/govulncheck-action` unchanged (the step below) — a strict gate that blocks on
-      # any reachable advisory. Only a consumer that opts in by committing a
-      # `.govulncheck-allow.txt` takes the fork path, which adds an `allow-file` input so it
-      # can risk-accept a reachable advisory that has NO upstream fix (`Fixed in: N/A`) —
-      # e.g. a server-side symbol a CLI links transitively via k8s.io/kubernetes or
-      # docker/docker — with an explicit, version-controlled justification, instead of
-      # wedging EVERY Go PR on that consumer indefinitely. Splitting on the file's presence
-      # keeps the official action on the path for every repo except opt-in ones, minimising
-      # the fork's blast radius. The official action has no allowlist input, so the opt-in
-      # path uses a thin devantler fork carrying the `allow-file` feature; swap it back to
-      # `golang/govulncheck-action` once the feature is upstreamed (the fork is Gerrit-ready
-      # at devantler/govulncheck-action@feat/allow-file). See the action README for the file
-      # format.
+      # By default this is a strict gate that blocks on any reachable advisory. A consumer
+      # that opts in by committing a `.govulncheck-allow.txt` (one accepted advisory ID per
+      # line) gets the allowlist path: it can risk-accept a reachable advisory that has NO
+      # upstream fix (`Fixed in: N/A`) — e.g. a server-side symbol a CLI links transitively
+      # via k8s.io/kubernetes or docker/docker — with an explicit, version-controlled
+      # justification, instead of wedging EVERY Go PR on that consumer indefinitely.
+      #
+      # We use the `devantler/govulncheck-action` fork (not the official
+      # `golang/govulncheck-action`) on every path because: (1) it adds the `allow-file`
+      # input the official lacks, and (2) its nested actions are SHA-pinned
+      # (actions/checkout, actions/setup-go), whereas the official action's are tag-pinned
+      # (actions/checkout@v4.1.1, actions/setup-go@v5.0.0). Consumers that enforce "require
+      # actions pinned to a full-length commit SHA" reject those tags at JOB SETUP, and
+      # GitHub validates every `uses:` in the job — even ones behind an unreached `if` — so
+      # merely *referencing* the official action wedged the whole vuln-scan job on such repos.
+      # With no allow-file the fork behaves exactly like the official (strict). Swap back to
+      # `golang/govulncheck-action` once both `allow-file` and SHA-pinned internals land
+      # upstream (the fork is Gerrit-ready at devantler/govulncheck-action@feat/allow-file).
+      # See the action README for the allow-file format.
       - name: 🔎 Detect govulncheck allowlist
         id: govulncheck-allow
         run: |
@@ -370,19 +375,12 @@ jobs:
           fi
 
       - name: 🛡️ Scan for known vulnerabilities
-        if: steps.govulncheck-allow.outputs.present == 'false'
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-        with:
-          repo-checkout: false
-          go-version-file: go.mod
-
-      - name: 🛡️ Scan for known vulnerabilities (with risk-acceptance allowlist)
-        if: steps.govulncheck-allow.outputs.present == 'true'
         uses: devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942 # feat/allow-file (fork; pending upstream)
         with:
           repo-checkout: false
           go-version-file: go.mod
-          allow-file: .govulncheck-allow.txt
+          # present ⇒ honour the allowlist (JSON mode, risk-accept listed IDs); absent ⇒ '' ⇒ strict.
+          allow-file: ${{ steps.govulncheck-allow.outputs.present == 'true' && '.govulncheck-allow.txt' || '' }}
 
   lint:
     name: 🧹 Lint - mega-linter


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
On consumer repos that enforce **"require actions pinned to a full-length commit SHA"** (e.g. `devantler-tech/ksail`, which has `sha_pinning_required: true`), the `🛡️ Vulnerability Scan` job fails at **"Set up job"** before govulncheck even runs:

```
The actions actions/checkout@v4.1.1 and actions/setup-go@v5.0.0 are not allowed in
devantler-tech/ksail because all actions must be pinned to a full-length commit SHA.
```

Because this scan is the org "Require workflows to pass before merging for Go" required workflow, that setup failure **wedges every Go PR** on such repos (e.g. ksail #4905 and #4945 are stuck on it).

## Root cause
The no-allowlist branch referenced `golang/govulncheck-action@v1.0.4`, whose `action.yml` pins its **nested** actions to tags (`actions/checkout@v4.1.1`, `actions/setup-go@v5.0.0`). GitHub validates **every `uses:` in a job at setup — even ones behind an unreached `if`** — so merely *referencing* the official action trips the SHA-pinning policy, even on repos that would take the fork (allowlist) path.

## Fix
Use the `devantler/govulncheck-action` fork on **all** paths — its nested actions are already SHA-pinned (`checkout@de0fac2`, `setup-go@7a3fe6cf`), and with no `allow-file` it behaves exactly like the official action (strict gate). The two conditional steps collapse into one, passing `allow-file` only when `.govulncheck-allow.txt` is present (so repos without it still get strict behaviour, no spurious warning).

## Verification
- YAML parses; `actionlint` clean for the changed lines.
- This repo's own vuln scan is skipped (`if: github.repository != 'devantler-tech/reusable-workflows'`), so verify downstream: once merged, ksail's blocked Go PRs should pass the vuln scan via their committed `.govulncheck-allow.txt` (4 risk-accepted, no-upstream-fix advisories).
- Revert to `golang/govulncheck-action` once both `allow-file` and SHA-pinned internals are upstream.

Draft for review — this affects **all** repos consuming `validate-go-project.yaml`.