### PR TITLE
fix(validate-go-project): scan under go.mod version, not 'stable'

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -378,6 +378,18 @@ jobs:
         uses: devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942 # feat/allow-file (fork; pending upstream)
         with:
           repo-checkout: false
+          # Scan under the SAME Go version the consumer actually ships (its go.mod), so
+          # govulncheck's stdlib analysis matches the produced binary. The fork's setup-go
+          # receives BOTH go-version (default 'stable') and go-version-file, and in
+          # actions/setup-go go-version WINS over go-version-file when both are non-empty —
+          # so without this override the scan always ran under 'stable' (currently 1.26.3)
+          # and IGNORED go.mod. That made the gate unable to clear a stdlib advisory whose
+          # only fix ships in a Go release newer than the runner's 'stable' channel: a
+          # consumer that bumps go.mod past 'stable' got an operational error
+          # ("go.mod requires go >= X; running go <stable>; GOTOOLCHAIN=local") instead of a
+          # passing scan, wedging its entire Go PR lane. Empty go-version-input lets setup-go
+          # honour go-version-file (go.mod), installing the exact shipped version.
+          go-version-input: ''
           go-version-file: go.mod
           # present ⇒ honour the allowlist (JSON mode, risk-accept listed IDs); absent ⇒ '' ⇒ strict.
           allow-file: ${{ steps.govulncheck-allow.outputs.present == 'true' && '.govulncheck-allow.txt' || '' }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `🛡️ Vulnerability Scan` job (govulncheck) wedges any consumer whose `go.mod`
requires a Go version newer than the runner's `setup-go` **`stable`** channel.

Root cause (live evidence from [ksail#5004](https://github.com/devantler-tech/ksail/pull/5004)'s
failing scan, run [26863554119](https://github.com/devantler-tech/ksail/actions/runs/26863554119)):

```
govulncheck: loading packages: err: exit status 1: stderr:
  go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)
##[error]govulncheck failed to run (exit 1) - operational error, not a scan result.
```

The govulncheck step passed **both** `go-version` (the fork's `go-version-input`,
default `'stable'`) **and** `go-version-file: go.mod` to `actions/setup-go`. In
setup-go, **`go-version` wins over `go-version-file`** when both are non-empty — so
the scan always ran under `stable` (currently **go1.26.3**) and silently **ignored
`go.mod`**. The log confirms it: `Setup go version spec stable` → `go version go1.26.3`.

Consequences:
- The gate can never clear a **stdlib** advisory whose only fix ships in a Go
  release newer than `stable` (e.g. `GO-2026-5037/5038/5039`, fixed in go1.26.4):
  bumping `go.mod` to the fixed version yields the operational error above instead
  of a passing scan, wedging the consumer's **entire Go PR lane**.
- More subtly, the scan tested a **different stdlib** than the binary the consumer
  actually ships (its `go.mod` version) — so its findings never matched reality.

This is org-wide: the PR vuln scan is the **org required-workflow** (ksail ruleset
`10320335`) pinned to `validate-go-project.yaml@refs/heads/main`, so every Go repo's
PR scan runs this job.

## Fix

Pass `go-version-input: ''` to the fork action so `setup-go` honours
`go-version-file: go.mod` and scans under the **exact Go version the consumer ships**.
`setup-go` installs that version directly (no toolchain mismatch, no `GOTOOLCHAIN`
download dance). Minimal, behaviour-correcting one-liner (+ explanatory comment).

## Blast radius & safety

- Repos already on a `stable`-or-older `go.mod`: unchanged scan version (their go.mod ≈ stable).
- Repos that **bump `go.mod` ahead of `stable`** (the wedged case): now scan under
  the shipped version and can clear "fixed-in-newer-Go" stdlib advisories. Combined
  with [ksail#5004](https://github.com/devantler-tech/ksail/pull/5004) (go.mod
  `1.26.3→1.26.4`), this unwedges the ksail Go PR lane.
- No allowlist behaviour change; `allow-file` path untouched.

## Validation

- `actionlint` clean on the changed step (only the pre-existing `code-quality`
  permission false-positive at line 552 remains — unrelated, actionlint lacks the
  new scope).
- YAML parses.

## Propagation

Org required-workflow is pinned to `main`, so merging this propagates immediately to
every repo's next PR vuln scan — no release/ref bump needed. ksail#5004's next scan
will then run under go1.26.4 and clear `GO-2026-5037/5038/5039`.

## Relation to roadmap

Complements [#282](https://github.com/devantler-tech/reusable-workflows/issues/282)
(harden the Go vuln-scan gate) — a *different* facet from the allow-file regression
[#283](https://github.com/devantler-tech/reusable-workflows/issues/283) targets. A
self-test that builds a consumer whose `go.mod` is ahead of `stable` and asserts the
scan honours it would guard this class of regression (the govulncheck job `if:`-skips
on the reusable-workflows repo itself, so this is the same hard-to-self-test surface
#283 covers).
