### PR TITLE
ci: free disk space in Go build/test/coverage jobs

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -377,6 +377,29 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🧹 Free disk space
+        # Reclaim ~11+ GB by removing large preinstalled toolchains a Go
+        # build/test never uses (Android SDK, .NET, GHC, …). A large consumer
+        # module's `go build`/`go test ./...` build cache (and the coverage
+        # job's `-race` binaries) can otherwise exhaust the runner disk —
+        # observed as a hard "No space left on device" failure. Targeted
+        # `rm -rf` only (avoids the slow apt-remove path); best-effort.
+        run: |
+          set -euo pipefail
+          before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/share/boost \
+            /usr/share/swift \
+            /opt/hostedtoolcache/CodeQL \
+            /opt/hostedtoolcache/PyPy \
+            /usr/local/share/powershell \
+            /usr/share/miniconda || true
+          after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          echo "Free disk on /: ${before}G -> ${after}G (gained $((after - before))G)"
+
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -401,6 +424,29 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: 🧹 Free disk space
+        # Reclaim ~11+ GB by removing large preinstalled toolchains a Go
+        # build/test never uses (Android SDK, .NET, GHC, …). A large consumer
+        # module's `go build`/`go test ./...` build cache (and the coverage
+        # job's `-race` binaries) can otherwise exhaust the runner disk —
+        # observed as a hard "No space left on device" failure. Targeted
+        # `rm -rf` only (avoids the slow apt-remove path); best-effort.
+        run: |
+          set -euo pipefail
+          before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/share/boost \
+            /usr/share/swift \
+            /opt/hostedtoolcache/CodeQL \
+            /opt/hostedtoolcache/PyPy \
+            /usr/local/share/powershell \
+            /usr/share/miniconda || true
+          after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          echo "Free disk on /: ${before}G -> ${after}G (gained $((after - before))G)"
 
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -430,6 +476,29 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: 🧹 Free disk space
+        # Reclaim ~11+ GB by removing large preinstalled toolchains a Go
+        # build/test never uses (Android SDK, .NET, GHC, …). A large consumer
+        # module's `go build`/`go test ./...` build cache (and the coverage
+        # job's `-race` binaries) can otherwise exhaust the runner disk —
+        # observed as a hard "No space left on device" failure. Targeted
+        # `rm -rf` only (avoids the slow apt-remove path); best-effort.
+        run: |
+          set -euo pipefail
+          before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/share/boost \
+            /usr/share/swift \
+            /opt/hostedtoolcache/CodeQL \
+            /opt/hostedtoolcache/PyPy \
+            /usr/local/share/powershell \
+            /usr/share/miniconda || true
+          after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          echo "Free disk on /: ${before}G -> ${after}G (gained $((after - before))G)"
 
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `build`, `test` and `coverage` jobs of `validate-go-project.yaml` run `go build` / `go test ./...` (coverage adds `-race`) on a bare `ubuntu-latest` with **no disk reclaim**. A large consumer module's build cache — plus the coverage job's `-race` binaries — can exhaust the runner disk, surfacing as a hard, non-deterministic failure:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/.../Worker_*.log'
```

**Observed live:** ksail PR [#5004](https://github.com/devantler-tech/ksail/pull/5004), run [26867544884](https://github.com/devantler-tech/ksail/actions/runs/26867544884) — the `🧪 Test` job died with exactly this error (the runner couldn't even flush its own diagnostic log because `/` was full). All other checks on that PR were green, so this is pure runner-infra exhaustion, not a code defect — yet it blocks the PR.

Because this workflow is the org-wide **required** Go workflow, the gap affects **every** Go repo, not just ksail.

## Fix

Add a targeted `🧹 Free disk space` step before `Setup Go` in each of the three Go-compiling jobs (`build`, `test`, `coverage`). It `rm -rf`s large preinstalled toolchains a Go build never uses (Android SDK ~9 GB, .NET, GHC, Boost, Swift, CodeQL, PyPy, PowerShell, Miniconda), reclaiming **~11+ GB** of headroom. It prints a `before → after` line for observability.

This mirrors the **proven** `🧹 Free disk space` step already in ksail's own `ci.yaml` system-test jobs — minus the `docker system prune` (unit tests/builds use no Docker). Targeted `rm -rf` only, avoiding the slow `apt-get remove` path; every removal is best-effort (`|| true`).

## Blast radius / safety

- **Additive & backward-compatible** — no `on: workflow_call` `inputs`/`outputs`/`secrets` change; pure step insertion.
- Only removes preinstalled directories irrelevant to `go build`/`go test`; the Go toolcache (`/opt/hostedtoolcache/Go`) is **not** touched, so `setup-go` is unaffected.
- Runtime cost is a few seconds of `rm` (not the slow apt path).

## Validation

- `actionlint .github/workflows/validate-go-project.yaml` — clean for the change (the only remaining note is the pre-existing `code-quality: write` scope, which `actionlint` doesn't yet recognise; unrelated to this diff).
- Diff is exactly the three identical 23-line steps (69 insertions, 0 deletions).

## Possible follow-up

The step is now duplicated 3× here and once in ksail's `ci.yaml` — a generic pattern. A natural next step is extracting it into a `free-disk-space` composite action in `devantler-tech/actions` and having both consume it. Left out of this PR to keep it small and contained.