### PR TITLE
feat(dependency-review): add Dependency Review reusable + required workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,12 @@ jobs:
       contents: read
       actions: read
 
+  test-dependency-review:
+    name: "[Test] Dependency Review - Default Settings"
+    uses: ./.github/workflows/dependency-review.yaml
+    permissions:
+      contents: read
+
   test-delete-workflow-runs-all:
     name: "[Test] Delete Workflow Runs - All Workflows"
     uses: ./.github/workflows/delete-workflow-runs.yaml
@@ -170,6 +176,7 @@ jobs:
     needs:
       [
         test-zizmor,
+        test-dependency-review,
         test-delete-workflow-runs-all,
         test-delete-workflow-runs-specific,
         test-delete-workflow-runs-minimal,
@@ -198,6 +205,7 @@ jobs:
         with:
           job-results: >-
             ${{ needs.test-zizmor.result }}
+            ${{ needs.test-dependency-review.result }}
             ${{ needs.test-delete-workflow-runs-all.result }}
             ${{ needs.test-delete-workflow-runs-specific.result }}
             ${{ needs.test-delete-workflow-runs-minimal.result }}

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,80 @@
+name: 🛡️ Dependency Review
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity:
+        description: >-
+          Block PRs on vulnerabilities of this severity or higher (`low`, `moderate`, `high`,
+          `critical`). Only applies when `warn-only` is false. Defaults to `critical`.
+        type: string
+        required: false
+        default: critical
+      fail-on-scopes:
+        description: >-
+          Comma-separated dependency scopes to block on (`runtime`, `development`, `unknown`).
+          Defaults to `runtime` so dev-only vulnerabilities don't block.
+        type: string
+        required: false
+        default: runtime
+      allow-licenses:
+        description: >-
+          Comma-separated allow-list of SPDX licenses. Empty means no allow-list is enforced.
+          Mutually exclusive with `deny-licenses`.
+        type: string
+        required: false
+        default: ""
+      deny-licenses:
+        description: >-
+          Comma-separated deny-list of SPDX licenses. Empty means no deny-list is enforced.
+          Mutually exclusive with `allow-licenses`.
+        type: string
+        required: false
+        default: ""
+      comment-summary-in-pr:
+        description: >-
+          Post the review summary as a PR comment (`always`, `on-failure`, `never`). Anything but
+          `never` requires the calling job to grant `pull-requests: write`. Defaults to `never`.
+        type: string
+        required: false
+        default: never
+      warn-only:
+        description: >-
+          When `true`, the action always succeeds (non-blocking), overriding `fail-on-severity`.
+          Defaults to `true` for safe org-wide rollout; set to `false` to enforce.
+        type: boolean
+        required: false
+        default: true
+  ### Required Workflow Triggers ###
+  pull_request:
+  merge_group:
+  ##################################
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
+    permissions:
+      contents: read # read the dependency graph / diff base..head
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 📑 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🛡️ Dependency Review
+        uses: devantler-tech/actions/dependency-review@521bc2e2bc4f24aae8ffa44a9365baece6f29b13 # unreleased — repin to the dependency-review composite's first release SHA before promotion
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+          fail-on-scopes: ${{ inputs.fail-on-scopes }}
+          allow-licenses: ${{ inputs.allow-licenses }}
+          deny-licenses: ${{ inputs.deny-licenses }}
+          comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
+          warn-only: ${{ inputs.warn-only }}

--- a/README.md
+++ b/README.md
@@ -92,6 +92,36 @@ jobs:
 
 </details>
 
+### 🛡️ Dependency Review
+
+<details>
+<summary>Click to expand</summary>
+
+[.github/workflows/dependency-review.yaml](.github/workflows/dependency-review.yaml) scans a pull request's dependency changes for known-vulnerable packages and disallowed licenses using [GitHub Dependency Review](https://github.com/actions/dependency-review-action). It is designed to run as an organization **Required Workflow** as well as via `workflow_call`.
+
+It is **non-blocking by default** (`warn-only: true`, `fail-on-severity: critical`) so it can be required org-wide without blocking existing PRs; set `warn-only: false` to enforce. With `comment-summary-in-pr: never` (the default) the job needs only `contents: read`.
+
+#### Usage
+
+```yaml
+jobs:
+  dependency-review:
+    uses: devantler-tech/reusable-workflows/.github/workflows/dependency-review.yaml@{ref} # ref
+```
+
+#### Inputs
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `fail-on-severity` | Block on vulnerabilities of this severity or higher (`low`, `moderate`, `high`, `critical`); only when `warn-only` is false. | `critical` |
+| `fail-on-scopes` | Comma-separated scopes to block on (`runtime`, `development`, `unknown`). | `runtime` |
+| `allow-licenses` | Comma-separated SPDX allow-list (empty = not enforced). Mutually exclusive with `deny-licenses`. | `""` |
+| `deny-licenses` | Comma-separated SPDX deny-list (empty = not enforced). Mutually exclusive with `allow-licenses`. | `""` |
+| `comment-summary-in-pr` | Post the summary as a PR comment (`always`, `on-failure`, `never`); anything but `never` needs `pull-requests: write`. | `never` |
+| `warn-only` | Report findings as warnings and always succeed (non-blocking); set `false` to enforce. | `true` |
+
+</details>
+
 ### 🚀 Deploy GitHub Pages
 
 <details>


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Part 2 of 3** of an org-wide **Dependency Review Required Workflow** (maintainer-directed). Depends on [actions#217](https://github.com/devantler-tech/actions/pull/217) (the composite).

## What
New `dependency-review.yaml` that is **both** a `workflow_call` reusable **and** an injectable Required Workflow. It mirrors `scan-for-workflow-vulnerabilities.yaml` exactly:
- `permissions: {}` top-level; the verbatim `### Required Workflow Triggers ###` block (`pull_request` + `merge_group`).
- Job gated `if: github.event_name != 'merge_group'`, `harden-runner` (audit) → `checkout` (persist-credentials:false) → call the `devantler-tech/actions/dependency-review` composite.
- `workflow_call` inputs pass through to the composite with the same safe defaults.

## Safe-by-default
`warn-only: true`, `fail-on-severity: critical`, `comment-summary-in-pr: never` → never hard-fails, and the job needs only `contents: read`. This is what makes it safe to require on **every** repo (incl. the private ones) without blocking a single open PR. Flip `warn-only` to enforce later.

## CI
`[Test] Dependency Review - Default Settings` self-test (`uses: ./.github/workflows/dependency-review.yaml`), wired into **both** the `ci-required-checks` `needs:` array and the `aggregate-job-checks` `job-results:` expression. README documented under `### 🛡️ Dependency Review`. `actionlint` clean.

## ⚠️ Sequencing — before promotion / before the ruleset
1. The composite is currently pinned to its **PR branch SHA** (`521bc2e`, unreleased) so this PR's CI exercises the full chain end-to-end. **Merge [actions#217](https://github.com/devantler-tech/actions/pull/217) first**, cut an actions release, then **repin** this workflow's composite `uses:` to the release SHA `# vX.Y.Z`.
2. **Part 3 — the org ruleset** (`Require workflows to pass before merging - DependencyReview`, mirroring `ScanGitHubActions` ruleset `14426226` → this workflow at `repository_id 1022337231`, `@refs/heads/main`) is applied **only after this merges to main** — otherwise every PR org-wide errors "workflow not found". I'll prepare the exact `gh api` command and surface it (plus the scoping + private-repo decisions) rather than create it unprompted, since a misordered required workflow blocks all PRs.

## Open maintainer decisions (carried to the report)
- **Scoping:** custom property `DependencyReview=true` (matches the `ScanGitHubActions` pattern, per-repo opt-out) vs `repository_name: ["~ALL"]`.
- **Private repos** (`wedding-app`, `ascoachingogvaner`): dependency-graph compare API returns 200 today; `warn-only` makes it non-blocking regardless — include now or hold?
- **Enforcement flip** (`warn-only: false`) timing + optional license policy.