### PR TITLE
test(govulncheck): prove .govulncheck-allow.txt allowlist is honored

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,7 +286,11 @@ jobs:
       - name: 🔒 Assert the gate pins the self-tested action SHA
         shell: bash
         env:
-          EXPECTED: "devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942"
+          # Match the full `uses:` line fragment, not the bare action ref — the ref
+          # also appears in surrounding comments in validate-go-project.yaml, so a
+          # bare-ref grep would false-pass if the real `uses:` SHA were changed while
+          # a comment still mentioned the old ref.
+          EXPECTED: "uses: devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942"
         run: |
           set -euo pipefail
           if ! grep -qF "$EXPECTED" .github/workflows/validate-go-project.yaml; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,120 @@ jobs:
       use-app-token: false
       dry-run: true
 
+  # ── Govulncheck allowlist self-test (regression guard for #282/#283) ──────────
+  # validate-go-project.yaml's vuln-scan gate honors a `.govulncheck-allow.txt`
+  # allowlist so consumers can risk-accept a reachable advisory with no upstream
+  # fix. That contract was silently lost for several releases (v5.4.1–v5.4.4, on
+  # the official action which has no allow-file input) with no test catching it.
+  # These jobs exercise the SAME action the gate uses against a pinned-vulnerable
+  # fixture (tests/govulncheck-allowlist) so the contract is provable and stable:
+  #   • allowlisted ⇒ the scan PASSES,  • strict (no allow-file) ⇒ the scan FAILS.
+  # The govulncheck job in validate-go-project.yaml is skipped on this repo, so it
+  # cannot self-test itself — hence a dedicated, faithful replica here.
+  test-govulncheck-allowlist-honored:
+    name: "[Test] Govulncheck Allowlist - Allowlisted Advisory Passes"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Mirror validate-go-project.yaml's scan step (same action SHA + inputs).
+      # The fixture reachably calls a GO-2021-0113 symbol; with that ID listed in
+      # .govulncheck-allow.txt the scan MUST pass. Keep this `uses:` in lockstep
+      # with validate-go-project.yaml — enforced by test-govulncheck-action-lockstep.
+      - name: 🛡️ Scan fixture with allowlist (must pass)
+        uses: devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942 # feat/allow-file (fork; pending upstream)
+        with:
+          repo-checkout: false
+          work-dir: tests/govulncheck-allowlist
+          go-version-input: ""
+          go-version-file: tests/govulncheck-allowlist/go.mod
+          allow-file: tests/govulncheck-allowlist/.govulncheck-allow.txt
+
+  test-govulncheck-strict-blocks:
+    name: "[Test] Govulncheck Allowlist - Strict Path Blocks"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Same fixture, but with NO allow-file: the strict path must FAIL on the
+      # reachable advisory. continue-on-error lets the run proceed so the next step
+      # can assert the failure, turning "the gate stopped blocking" into a red test.
+      - name: 🛡️ Scan fixture without allowlist (expected to fail)
+        id: scan
+        continue-on-error: true
+        uses: devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942 # feat/allow-file (fork; pending upstream)
+        with:
+          repo-checkout: false
+          work-dir: tests/govulncheck-allowlist
+          go-version-input: ""
+          go-version-file: tests/govulncheck-allowlist/go.mod
+          allow-file: ""
+
+      - name: ✅ Assert the strict scan blocked
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.scan.outcome }}
+        run: |
+          if [ "$OUTCOME" != "failure" ]; then
+            echo "::error::Strict govulncheck scan should FAIL on the reachable GO-2021-0113 fixture, but its outcome was '$OUTCOME'. The strict gate is no longer blocking reachable advisories."
+            exit 1
+          fi
+          echo "Strict scan correctly blocked the reachable advisory ✅"
+
+  test-govulncheck-action-lockstep:
+    name: "[Test] Govulncheck Allowlist - Gate Pins Self-Tested Action"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # `uses:` cannot be parametrized, so the two scan jobs above hard-code the
+      # govulncheck action SHA. This guard asserts validate-go-project.yaml pins
+      # that SAME SHA, so the self-test always exercises the real gate. If the gate
+      # is ever swapped to an action without allow-file support, this check goes red
+      # and forces the self-test to be updated — at which point the allowlisted case
+      # fails too. That is what makes this suite catch the v5.4.1–v5.4.4 regression.
+      - name: 🔒 Assert the gate pins the self-tested action SHA
+        shell: bash
+        env:
+          EXPECTED: "devantler/govulncheck-action@a7e51f717da0ebf10c4dfc8a31d4d45b9736a942"
+        run: |
+          set -euo pipefail
+          if ! grep -qF "$EXPECTED" .github/workflows/validate-go-project.yaml; then
+            echo "::error::validate-go-project.yaml no longer pins '$EXPECTED'. If the govulncheck action was changed intentionally, update both scan jobs in ci.yaml (test-govulncheck-allowlist-honored / test-govulncheck-strict-blocks) and this EXPECTED value so the allowlist self-test keeps exercising the real gate."
+            exit 1
+          fi
+          echo "validate-go-project.yaml pins the self-tested govulncheck action ✅"
+
   ci-required-checks:
     name: "CI - Required Checks"
     runs-on: ubuntu-latest
@@ -191,6 +305,9 @@ jobs:
         test-sync-cluster-policies,
         test-update-agent-skills,
         test-template-sync,
+        test-govulncheck-allowlist-honored,
+        test-govulncheck-strict-blocks,
+        test-govulncheck-action-lockstep,
       ]
     permissions: {}
     if: ${{ always() }}
@@ -220,3 +337,6 @@ jobs:
             ${{ needs.test-sync-cluster-policies.result }}
             ${{ needs.test-update-agent-skills.result }}
             ${{ needs.test-template-sync.result }}
+            ${{ needs.test-govulncheck-allowlist-honored.result }}
+            ${{ needs.test-govulncheck-strict-blocks.result }}
+            ${{ needs.test-govulncheck-action-lockstep.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,6 +228,10 @@ jobs:
       # Same fixture, but with NO allow-file: the strict path must FAIL on the
       # reachable advisory. continue-on-error lets the run proceed so the next step
       # can assert the failure, turning "the gate stopped blocking" into a red test.
+      # output-file captures the scan output so the assertion can confirm the run
+      # actually detected the advisory — distinguishing a real block from an
+      # operational error (e.g. toolchain/install failure) that would otherwise make
+      # a bare "the step failed" check pass for the wrong reason.
       - name: 🛡️ Scan fixture without allowlist (expected to fail)
         id: scan
         continue-on-error: true
@@ -238,17 +242,24 @@ jobs:
           go-version-input: ""
           go-version-file: tests/govulncheck-allowlist/go.mod
           allow-file: ""
+          output-file: govulncheck-strict.txt
 
-      - name: ✅ Assert the strict scan blocked
+      - name: ✅ Assert the strict scan blocked on the advisory
         shell: bash
         env:
           OUTCOME: ${{ steps.scan.outcome }}
         run: |
+          set -euo pipefail
           if [ "$OUTCOME" != "failure" ]; then
             echo "::error::Strict govulncheck scan should FAIL on the reachable GO-2021-0113 fixture, but its outcome was '$OUTCOME'. The strict gate is no longer blocking reachable advisories."
             exit 1
           fi
-          echo "Strict scan correctly blocked the reachable advisory ✅"
+          if ! grep -q "GO-2021-0113" govulncheck-strict.txt; then
+            echo "::error::Strict scan failed, but its output did not report GO-2021-0113 — the failure was operational (e.g. toolchain/install), not a real vulnerability block. Output:"
+            cat govulncheck-strict.txt || echo "(no output captured)"
+            exit 1
+          fi
+          echo "Strict scan correctly blocked on the reachable advisory ✅"
 
   test-govulncheck-action-lockstep:
     name: "[Test] Govulncheck Allowlist - Gate Pins Self-Tested Action"

--- a/tests/govulncheck-allowlist/.govulncheck-allow.txt
+++ b/tests/govulncheck-allowlist/.govulncheck-allow.txt
@@ -1,0 +1,5 @@
+# Risk-accepted advisories for the govulncheck allowlist self-test fixture.
+# One advisory ID per line; "#" comments and blank lines are ignored.
+# GO-2021-0113 is the reachable advisory in the pinned golang.org/x/text v0.3.0
+# (see main.go). Listing it here is what the "allowlisted ⇒ pass" case asserts.
+GO-2021-0113

--- a/tests/govulncheck-allowlist/go.mod
+++ b/tests/govulncheck-allowlist/go.mod
@@ -1,0 +1,5 @@
+module example.com/govulncheck-allowlist-fixture
+
+go 1.23
+
+require golang.org/x/text v0.3.0

--- a/tests/govulncheck-allowlist/go.mod
+++ b/tests/govulncheck-allowlist/go.mod
@@ -1,5 +1,5 @@
 module example.com/govulncheck-allowlist-fixture
 
-go 1.23
+go 1.26
 
 require golang.org/x/text v0.3.0

--- a/tests/govulncheck-allowlist/go.sum
+++ b/tests/govulncheck-allowlist/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/tests/govulncheck-allowlist/main.go
+++ b/tests/govulncheck-allowlist/main.go
@@ -11,6 +11,12 @@
 // or advisory GO-2021-0113 ever stops being reported by govulncheck, repoint
 // this module (and the ID in .govulncheck-allow.txt) at another pinned
 // dependency version with a known reachable advisory and re-tidy.
+//
+// The `go` directive in go.mod must satisfy govulncheck@latest's minimum Go
+// version (the action installs it with GOTOOLCHAIN=local, so it cannot upgrade
+// the toolchain). It is kept at the portfolio's current Go line; bump it if a
+// newer govulncheck raises that floor (the allowlisted-passes case goes red and
+// surfaces the requirement if it falls behind).
 package main
 
 import (

--- a/tests/govulncheck-allowlist/main.go
+++ b/tests/govulncheck-allowlist/main.go
@@ -1,0 +1,32 @@
+// Package main is a self-contained fixture for the govulncheck allowlist
+// self-test (.github/workflows/test-govulncheck-allowlist.yaml). It REACHABLY
+// calls a function in a pinned-vulnerable dependency so govulncheck reports a
+// known advisory, letting CI prove that validate-go-project.yaml's
+// `.govulncheck-allow.txt` allowlist is honored (allowlisted ⇒ pass) and that
+// the strict path still blocks (no allow-file ⇒ fail).
+//
+// Refreshing the fixture: the dependency is PINNED to a vulnerable version on
+// purpose, so the advisory is reported regardless of any upstream fix — it does
+// not depend on a live advisory staying unpatched. If golang.org/x/text v0.3.0
+// or advisory GO-2021-0113 ever stops being reported by govulncheck, repoint
+// this module (and the ID in .govulncheck-allow.txt) at another pinned
+// dependency version with a known reachable advisory and re-tidy.
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/text/language"
+)
+
+func main() {
+	// golang.org/x/text@v0.3.0's BCP 47 parser is subject to GO-2021-0113
+	// (index-out-of-range / DoS). Calling language.Parse makes the advisory
+	// reachable, so govulncheck reports it as a called vulnerability.
+	tag, err := language.Parse("en-US")
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return
+	}
+	fmt.Println("parsed:", tag)
+}

--- a/tests/govulncheck-allowlist/main.go
+++ b/tests/govulncheck-allowlist/main.go
@@ -1,5 +1,5 @@
 // Package main is a self-contained fixture for the govulncheck allowlist
-// self-test (.github/workflows/test-govulncheck-allowlist.yaml). It REACHABLY
+// self-test (the test-govulncheck-* jobs in .github/workflows/ci.yaml). It REACHABLY
 // calls a function in a pinned-vulnerable dependency so govulncheck reports a
 // known advisory, letting CI prove that validate-go-project.yaml's
 // `.govulncheck-allow.txt` allowlist is honored (allowlisted ⇒ pass) and that


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #283 (child of the #282 vuln-scan-gate hardening roadmap epic).

## Problem

`validate-go-project.yaml`'s vulnerability-scan gate honors a `.govulncheck-allow.txt` allowlist so consumers can risk-accept a **reachable** advisory with no upstream fix (`Fixed in: N/A`). Nothing tested that contract — so when the gate was swapped to the official `golang/govulncheck-action` for `v5.4.1`–`v5.4.4` (which has **no** `allow-file` input), the allowlist was **silently ignored** for several releases and no CI failure flagged it. The regression only surfaced as wedged consumer Go PR lanes.

## What this adds

A self-test that makes the allowlist contract a **tested invariant** of the gate:

| Job | Asserts |
|---|---|
| `[Test] Govulncheck Allowlist - Allowlisted Advisory Passes` | with the advisory ID in `.govulncheck-allow.txt`, the scan **passes** |
| `[Test] Govulncheck Allowlist - Strict Path Blocks` | with **no** allow-file, the same scan **fails** on the reachable advisory |
| `[Test] Govulncheck Allowlist - Gate Pins Self-Tested Action` | `validate-go-project.yaml` pins the **same** govulncheck action SHA the self-test exercises |

All three are wired into `CI - Required Checks`.

### Fixture — `tests/govulncheck-allowlist/`
A self-contained Go module that **reachably calls** `language.Parse` from a **pinned** `golang.org/x/text v0.3.0`, so `govulncheck` always reports `GO-2021-0113` regardless of any upstream fix (the dependency is pinned vulnerable on purpose — it does not depend on a live advisory staying unpatched). `main.go` documents how to repoint it if that advisory ever stops being reported.

### Why the lockstep guard
`uses:` cannot be parametrized, so the two scan jobs hard-code the govulncheck action SHA. The lockstep job asserts `validate-go-project.yaml` pins that exact SHA. This is what makes the suite catch the **`v5.4.1`–`v5.4.4` regression class**: if the gate is ever swapped to an action without `allow-file` support, the lockstep check goes red and forces the self-test to be updated — at which point the *allowlisted-passes* case fails too.

## Acceptance criteria (from #283)
- [x] Self-test proves Case A (allowlisted ⇒ pass) and Case B (strict ⇒ fail) against the actual govulncheck scan step (same action SHA).
- [x] Fixture is self-contained and pins the dependency; refresh procedure documented in `main.go`.
- [x] Would have failed on `v5.4.1`–`v5.4.4` — via the lockstep guard (an allow-file-less swap turns Case A red).
- [x] No new external network dependency beyond the existing govulncheck DB fetch.

## Validation
- Fixture verified locally: strict `govulncheck ./...` exits 3 on `GO-2021-0113`; the action's JSON allowlist logic yields empty blocking set when the ID is allowlisted (pass) and a non-empty set when it isn't (fail).
- `gofmt`/`go vet` clean on the fixture; `ci.yaml` parses; new jobs `actionlint`-clean (pre-existing `code-quality`-permission warnings are unrelated).

## Notes
The `#282` epic also tracks retiring the `devantler/govulncheck-action` fork once `allow-file` is upstreamed into `golang/govulncheck-action` — that is maintainer-side. This guard makes that future fork→upstream swap **safe**: it stays green only while the allowlist contract holds.