### PR TITLE
fix(dependency-review): no-op the job on non-PR caller events

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -55,7 +55,12 @@ on:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group'
+    # Dependency Review needs a PR diff (base..head is auto-resolved only on pull_request /
+    # pull_request_target). On any other caller event — push, merge_group, schedule, … — the
+    # underlying action has no diff to inspect and errors out, so guard with an allow-list of the
+    # supported events and let the job no-op (skipped → green) everywhere else. This keeps the
+    # reusable workflow safe to wire into a push-triggered CI without breaking it.
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     permissions:
       contents: read # read the dependency graph / diff base..head
     steps:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — main CI is red on every push

`🧪 CI` (and the `CI - Required Checks` aggregator) has been **failing on every push to `main`** since the Dependency Review reusable workflow + its self-test landed (#286). The failing job is `[Test] Dependency Review - Default Settings / dependency-review`.

**Root cause.** Dependency Review fundamentally needs a PR diff: the underlying `actions/dependency-review-action` auto-resolves `base..head` **only on `pull_request` / `pull_request_target`** (per the composite's own `base-ref`/`head-ref` docs: *"required for other events"*). The reusable workflow exposes no `base-ref`/`head-ref` inputs, so it only ever supports the auto-defaulted PR case.

The job guard was a **deny-list** — `if: github.event_name != 'merge_group'`. When the CI self-test calls the reusable workflow on a **`push` to main**, `github.event_name` propagates as `push`, the guard lets the job run, and the action errors out with no diff → red CI on every push.

## Fix

Replace the deny-list with an **allow-list** of the only events the action supports:

```yaml
if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
```

Now the job runs on PR events (self-test on this repo's own PRs, and consumers wiring it into `pull_request` CI) and **no-ops (skipped → green)** on `push` / `merge_group` / `schedule` / anything else. The `aggregate-job-checks` aggregator already treats `skipped` as a pass (many other test jobs are skipped on push), so this turns `CI - Required Checks` green again. It also makes the reusable workflow **safe to wire into a push-triggered CI in any consumer repo** without breaking it — a blast-radius improvement, not just a local fix.

## Scope

- Behaviour on PRs is unchanged (still scans the diff).
- Orthogonal to #288 (warn-only default ignored on direct self-trigger) — that's a separate concern about empty `workflow_call` inputs on PR self-trigger and is **not** addressed here (one concern per PR).

## Validation

- `actionlint` clean on the changed `dependency-review.yaml`. (The two `code-quality` permission-scope warnings in `ci.yaml` are pre-existing and a false positive of the local actionlint version — `code-quality` is a valid GitHub permission scope; untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)