### PR TITLE
fix(dependency-review): honor warn-only default on direct self-trigger

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -74,12 +74,58 @@ jobs:
         with:
           persist-credentials: false
 
+      # On the direct self-trigger (the `### Required Workflow Triggers ###`
+      # pull_request event) the `inputs` context is empty, so the `workflow_call`
+      # input defaults — including `warn-only: true` — do NOT apply. Passing those
+      # empty strings straight to the composite overrides ITS defaults too, flipping
+      # the self-trigger into enforce mode and hard-blocking this repo's own PRs (e.g.
+      # an intentionally-vulnerable test fixture). Resolve the effective values here
+      # instead, mirroring this workflow's documented defaults. The discriminator is
+      # bash-side (not a `${{ }}` expression, which would mis-coerce the boolean
+      # `warn-only: false` case): `github.event_name` is inherited from the caller on
+      # workflow_call so it can't tell the two apart, but the boolean `warn-only` input
+      # has `default: true` and is therefore never empty on a real workflow_call — only
+      # an empty value means "direct self-trigger". See #288.
+      - name: ⚙️ Resolve effective inputs
+        id: cfg
+        shell: bash
+        env:
+          IN_FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
+          IN_FAIL_ON_SCOPES: ${{ inputs.fail-on-scopes }}
+          IN_ALLOW_LICENSES: ${{ inputs.allow-licenses }}
+          IN_DENY_LICENSES: ${{ inputs.deny-licenses }}
+          IN_COMMENT_SUMMARY: ${{ inputs.comment-summary-in-pr }}
+          IN_WARN_ONLY: ${{ inputs.warn-only }}
+        run: |
+          set -euo pipefail
+          if [ -z "$IN_WARN_ONLY" ]; then
+            # Direct self-trigger: no workflow_call inputs → use documented defaults.
+            {
+              echo "fail-on-severity=critical"
+              echo "fail-on-scopes=runtime"
+              echo "allow-licenses="
+              echo "deny-licenses="
+              echo "comment-summary-in-pr=never"
+              echo "warn-only=true"
+            } >> "$GITHUB_OUTPUT"
+          else
+            # Called via workflow_call: input defaults applied → pass values through.
+            {
+              echo "fail-on-severity=$IN_FAIL_ON_SEVERITY"
+              echo "fail-on-scopes=$IN_FAIL_ON_SCOPES"
+              echo "allow-licenses=$IN_ALLOW_LICENSES"
+              echo "deny-licenses=$IN_DENY_LICENSES"
+              echo "comment-summary-in-pr=$IN_COMMENT_SUMMARY"
+              echo "warn-only=$IN_WARN_ONLY"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 🛡️ Dependency Review
         uses: devantler-tech/actions/dependency-review@521bc2e2bc4f24aae8ffa44a9365baece6f29b13 # unreleased — repin to the dependency-review composite's first release SHA before promotion
         with:
-          fail-on-severity: ${{ inputs.fail-on-severity }}
-          fail-on-scopes: ${{ inputs.fail-on-scopes }}
-          allow-licenses: ${{ inputs.allow-licenses }}
-          deny-licenses: ${{ inputs.deny-licenses }}
-          comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
-          warn-only: ${{ inputs.warn-only }}
+          fail-on-severity: ${{ steps.cfg.outputs.fail-on-severity }}
+          fail-on-scopes: ${{ steps.cfg.outputs.fail-on-scopes }}
+          allow-licenses: ${{ steps.cfg.outputs.allow-licenses }}
+          deny-licenses: ${{ steps.cfg.outputs.deny-licenses }}
+          comment-summary-in-pr: ${{ steps.cfg.outputs.comment-summary-in-pr }}
+          warn-only: ${{ steps.cfg.outputs.warn-only }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #288.

## Problem

`dependency-review.yaml` is a `workflow_call` reusable workflow whose `warn-only` input documents *"Defaults to `true` for safe org-wide rollout."* It also carries a direct `pull_request` self-trigger (the `### Required Workflow Triggers ###` block) so it self-tests on this repo's own PRs — and the org ruleset now registers it as a **required workflow** on `main`.

On that direct self-trigger the `inputs` context is empty, so the `workflow_call` input **defaults do not apply**. The job passed `warn-only: ${{ inputs.warn-only }}` → an **empty string**, which overrides the composite's own `default: true` → the action runs in **enforce mode** and hard-blocks the repo's own PRs on any vulnerable dependency — the opposite of the documented intent. Surfaced by #287, whose intentionally-vulnerable Go fixture (`golang.org/x/text@0.3.0`) leaves a permanently-red, now-blocking `dependency-review` check.

## Fix (option 1 from #288 — best matches the documented intent)

Resolve the effective inputs in a small bash step before the composite, mirroring this workflow's documented defaults on the direct self-trigger and passing inputs through on `workflow_call`:

- **Direct self-trigger** (empty inputs) → `warn-only: true` + the documented `fail-on-severity: critical` / `fail-on-scopes: runtime` / `comment-summary-in-pr: never`.
- **`workflow_call`** → pass `inputs.*` straight through, preserving the explicit `warn-only: false` enforce case for consumers.

### Why bash, keyed on empty `warn-only`

`github.event_name` is **inherited from the caller** on `workflow_call`, so it can't distinguish a direct self-trigger from a consumer's `pull_request` call. The reliable discriminator is that the boolean `warn-only` input has `default: true` and is therefore **never empty on a real `workflow_call`** — only the direct self-trigger leaves it empty. The check is done bash-side (not in a `${{ }}` expression) to avoid GitHub's falsy coercion mangling the boolean `warn-only: false` case (the `x != '' && x || true` trap noted in #288).

## Not a security weakening

This honors the workflow's **own documented default** (warn-only rollout) on rw's own PRs; the `enable-auto-merge` + `scan-for-workflow-vulnerabilities` + `CI - Required Checks` gates remain the enforcing checks here. Consumer enforcement (`warn-only: false`) is unchanged. Option 2 from #288 (a `config-file`/`allow-ghsas` risk-acceptance passthrough, keeping enforce mode + allow-listing the fixture) is the stricter alternative but requires extending the still-**unreleased** `devantler-tech/actions/dependency-review` composite — deferred until that composite is released and repinned (see the `# unreleased` note on the `uses:` line).

## Unblock chain

The required `dependency-review` check on PRs runs `dependency-review.yaml@refs/heads/main`, so once this lands on `main`, re-running/rebasing **#287** clears its blocking `dependency-review` failure (#287's fixture is intentionally vulnerable but the self-trigger will then be warn-only).

## Validation

- `actionlint .github/workflows/dependency-review.yaml` → clean (exit 0).
- YAML parses.
- `workflow_call` path unchanged for consumers and for the `test-dependency-review` self-test (calls via `workflow_call` with defaults → `warn-only` non-empty → pass-through branch).