### PR TITLE
ci: freeze govulncheck self-test fixture from Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,12 +12,21 @@ updates:
   # can prove the allow-file contract against a real reachable advisory
   # (GO-2021-0113). Dependabot must never bump or security-"fix" it — a patched
   # version removes the advisory and breaks the strict-path assertion. This block
-  # exists solely to carry an `ignore` condition (which, unlike
-  # open-pull-requests-limit, suppresses BOTH version AND security update PRs),
-  # freezing the fixture entirely.
+  # exists solely to carry the `ignore` condition below that freezes the fixture.
+  #
+  # Why a bare `dependency-name: "*"` (no `versions`, no `update-types`): in the
+  # config file an `ignore` entry restricted only by name — with no version range
+  # and no `update-types` — matches ALL versions of the dependency, so Dependabot
+  # raises neither version-update nor security-update PRs for it. `update-types`
+  # would NOT work here: it accepts only `version-update:semver-{major,minor,patch}`
+  # (there is no `security` value) and never gates security updates. The wildcard
+  # name match with no version constraint is the only thing that also freezes the
+  # security path. See "Controlling which dependencies are updated by Dependabot".
   - package-ecosystem: gomod
     directory: /tests/govulncheck-allowlist
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,18 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+  # The govulncheck allowlist self-test fixture (tests/govulncheck-allowlist)
+  # DELIBERATELY pins a vulnerable golang.org/x/text v0.3.0 so the CI self-test
+  # (ci.yaml: test-govulncheck-allowlist-honored / test-govulncheck-strict-blocks)
+  # can prove the allow-file contract against a real reachable advisory
+  # (GO-2021-0113). Dependabot must never bump or security-"fix" it — a patched
+  # version removes the advisory and breaks the strict-path assertion. This block
+  # exists solely to carry an `ignore` condition (which, unlike
+  # open-pull-requests-limit, suppresses BOTH version AND security update PRs),
+  # freezing the fixture entirely.
+  - package-ecosystem: gomod
+    directory: /tests/govulncheck-allowlist
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The govulncheck allowlist self-test fixture (`tests/govulncheck-allowlist`) **deliberately** pins a vulnerable `golang.org/x/text v0.3.0` so the CI self-test can prove the allow-file contract against a real, reachable advisory (`GO-2021-0113`):

- `test-govulncheck-allowlist-honored` — advisory **allowlisted ⇒ scan PASSES**
- `test-govulncheck-strict-blocks` — no allow-file ⇒ scan **FAILS**, asserted via `grep -q "GO-2021-0113" govulncheck-strict.txt` ([`ci.yaml:257`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/ci.yaml#L257))

Because **Dependabot security updates** auto-open PRs for *any* vulnerable dependency found in a scanned manifest (independent of the `package-ecosystem` blocks in `dependabot.yaml`), every new patched `x/text` release makes Dependabot try to "fix" the fixture — e.g. [#293](https://github.com/devantler-tech/reusable-workflows/pull/293) (`0.3.0 → 0.3.8`). The bump removes `GO-2021-0113`, so the strict-path scan finds nothing to block and the assertion fails. This is a **recurring self-inflicted CI red** that keeps blocking otherwise-routine dependency PRs.

## Fix

Add a `gomod` block scoped to `/tests/govulncheck-allowlist` carrying a wildcard `ignore`. Per GitHub's docs, `ignore` conditions suppress **both version and security** update PRs (whereas `open-pull-requests-limit: 0` only stops version updates — security updates have a separate internal limit). A wildcard `ignore` therefore freezes the fixture entirely so Dependabot leaves its intentionally-vulnerable pin alone.

```yaml
- package-ecosystem: gomod
  directory: /tests/govulncheck-allowlist
  schedule:
    interval: daily
  ignore:
    - dependency-name: "*"
```

## Follow-up

- [#293](https://github.com/devantler-tech/reusable-workflows/pull/293) can never go green (it removes the advisory the self-test depends on) and should be **closed** — once this lands, Dependabot will not reopen it.
- Relates to the govulncheck-gate hardening lineage (#282 / #283 / #292).

## Validation

`dependabot.yaml` parses cleanly (`yq -o=json`); the new block is config-only and additive — no workflow or fixture behavior changes.