### PR TITLE
ci: exempt internal devantler-tech deps from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,9 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+      # devantler-tech actions/workflows are our own code — bump now, no cooldown.
+      exclude:
+        - "devantler-tech/*"
   # The govulncheck allowlist self-test fixture (tests/govulncheck-allowlist)
   # DELIBERATELY pins a vulnerable golang.org/x/text v0.3.0 so the CI self-test
   # (ci.yaml: test-govulncheck-allowlist-honored / test-govulncheck-strict-blocks)


### PR DESCRIPTION
## What

Adds `exclude: ["devantler-tech/*"]` to the Dependabot `github-actions` cooldown. Per Dependabot's `WildcardMatcher`, `*` compiles to `.*` (anchored, matches across `/`), so it covers both `devantler-tech/actions` and reusable-workflow refs like `devantler-tech/reusable-workflows/.github/workflows/<file>.yaml`.

## Why

We trust our own code (CI is the gate), so internal `devantler-tech/*` bumps shouldn't wait in cooldown like third-party deps — they should land immediately.

Companion to devantler-tech/monorepo#1782 (portfolio-wide pass across every repo's Dependabot/Renovate config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
