### PR TITLE
ci(dependency-review): pin composite to released v5.4.0 SHA

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -121,7 +121,7 @@ jobs:
           fi
 
       - name: 🛡️ Dependency Review
-        uses: devantler-tech/actions/dependency-review@521bc2e2bc4f24aae8ffa44a9365baece6f29b13 # unreleased — repin to the dependency-review composite's first release SHA before promotion
+        uses: devantler-tech/actions/dependency-review@cbfd433920d036c336b00b35af4c82f8e700affe # v5.4.0
         with:
           fail-on-severity: ${{ steps.cfg.outputs.fail-on-severity }}
           fail-on-scopes: ${{ steps.cfg.outputs.fail-on-scopes }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`.github/workflows/dependency-review.yaml` (a **released, required** reusable workflow — added in #286, repo now at v5.5.5) still pins its internal `devantler-tech/actions/dependency-review` composite to an **unreleased intermediate WIP commit**:

```
uses: devantler-tech/actions/dependency-review@521bc2e2bc4f24aae8ffa44a9365baece6f29b13 # unreleased — repin to the dependency-review composite's first release SHA before promotion
```

`521bc2e` is the *"feat(dependency-review): add composite … **First half**"* commit. The inline note asked to repin "to the first release SHA before promotion" — but the workflow has long since been promoted, and the composite has shipped in `devantler-tech/actions` releases since **v5.3.0**. So the deferred cleanup was simply never done.

Pinning a required workflow to a WIP commit that lives only in a feature branch's history is a **supply-chain risk**: such a commit is unreachable from any tag and can be orphaned/garbage-collected, which would break the pin org-wide.

## Change

Repin to the **v5.4.0** release SHA (`cbfd433`) and drop the stale note:

```
uses: devantler-tech/actions/dependency-review@cbfd433920d036c336b00b35af4c82f8e700affe # v5.4.0
```

## Safety — behaviour-preserving

The composite `action.yaml` is **byte-identical** between the old pin and v5.4.0 (verified: same blob `cb4114b2` at `521bc2e`, `v5.3.0`, and `v5.4.0`), so this changes **no** scan behaviour — it only moves the pin onto an immutable, released, dependabot-trackable tag SHA.

- `actionlint` — clean
- `zizmor` — no findings
- `uses:` resolves — `dependency-review/action.yaml` present at v5.4.0

Relates to #282 (harden & stabilize the portfolio's security gates). `ci:` → patch release so consumers' dependabot picks up the hardened pin.