### PR TITLE
ci(template-sync): add harden-runner egress audit as first step

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -82,6 +82,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: 🛡️ Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: 🧮 Resolve template repo name
         id: template
         if: ${{ inputs.use-app-token }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`template-sync.yaml` is the **only** reusable workflow in this repo whose job has **no `step-security/harden-runner` step**. The other 14 workflows all pin `step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4` with `egress-policy: audit` as their **first** step (e.g. `create-release.yaml:21`, `dependency-review.yaml:67`, `deploy-github-pages.yaml:47`, `validate-go-project.yaml:42`).

This violates the repo's own contract — `AGENTS.md` rule 3:

> Include `step-security/harden-runner` as the first step of every job with `egress-policy: audit`.

It's also the workflow where the control matters most: `template-sync` runs **authenticated git operations** under a GitHub App token — it clones the upstream template repo and pushes a sync branch to the caller repo. Running those without egress auditing is exactly the exfiltration surface harden-runner is meant to observe.

## Fix

Add the standard harden-runner step (same pinned SHA + `egress-policy: audit` as every sibling) as the **first** step of the `template-sync` job. Purely additive — `+5 -0`, no behaviour change to the sync logic.

```yaml
    steps:
      - name: 🛡️ Harden runner
        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
        with:
          egress-policy: audit

      - name: 🧮 Resolve template repo name
        ...
```

## Validation

- The repo's `ci.yaml` runs **Zizmor** (`test-zizmor`) over all workflows on every PR — adding harden-runner improves, never regresses, that posture.
- Single-job workflow (`template-sync`), so this is the only insertion needed for full parity.
- Pin matches the SHA already used across all 14 sibling workflows (no new/divergent action version introduced).

Opened as a **draft** per the maintenance contract; will be kept review-ready (CI green) while it awaits promotion.
