### PR TITLE
docs(create-release): document required APP_CLIENT_ID variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ flowchart TD
 
 [.github/workflows/create-release.yaml](.github/workflows/create-release.yaml) is a workflow used to create releases using semantic-release.
 
+The release is published with a GitHub App token, so the caller must set the `APP_CLIENT_ID` repository/organization **variable** alongside the `APP_PRIVATE_KEY` **secret**. The App needs `contents: write` (tags/releases) and `issues: write` + `pull-requests: write` (release comments).
+
 #### Usage
 
 ```yaml
@@ -47,10 +49,11 @@ jobs:
 
 #### Secrets and Inputs
 
-| Key               | Type            | Default | Required | Description                                                  |
-|-------------------|-----------------|---------|----------|--------------------------------------------------------------|
-| `APP_PRIVATE_KEY` | Secret          | -       | Yes      | GitHub App private key                                       |
-| `dry-run`         | Input (boolean) | `false` | No       | Run semantic-release in dry-run mode (no tags or publishes)  |
+| Key               | Type            | Default | Required | Description                                                       |
+|-------------------|-----------------|---------|----------|-------------------------------------------------------------------|
+| `APP_CLIENT_ID`   | Variable        | -       | Yes      | GitHub App client ID used to mint the release token               |
+| `APP_PRIVATE_KEY` | Secret          | -       | Yes      | GitHub App private key (paired with the `APP_CLIENT_ID` variable) |
+| `dry-run`         | Input (boolean) | `false` | No       | Run semantic-release in dry-run mode (no tags or publishes)       |
 
 </details>
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`create-release.yaml` mints its release token from `vars.APP_CLIENT_ID`:

```yaml
- name: 🔑 Get GitHub App Token
  uses: actions/create-github-app-token@…
  with:
    client-id: ${{ vars.APP_CLIENT_ID }}
    private-key: ${{ secrets.APP_PRIVATE_KEY }}
```

…but the README's **Create Release → Secrets and Inputs** table documents only `APP_PRIVATE_KEY`. A caller who follows the docs sets just the secret and the workflow fails to mint a token (the App client ID is never provided). The variable was introduced in #226 (`fix(create-release): use client-id input`) but the docs were never updated to match — a missed definition-of-done docs sync.

## Change

- Document the required **`APP_CLIENT_ID`** repository/organization variable in the create-release section (new table row + a prose note mirroring how the `template-sync` section documents its App-token variable).
- Note the App permission scopes the workflow grants (`contents`/`issues`/`pull-requests: write`).

Docs-only; no workflow behaviour change.

## Follow-up (separate, tracked)

`create-release` is the **lone** App-token workflow using `client-id`/`APP_CLIENT_ID`; the other seven (`enable-auto-merge`, `scan-for-todo-comments`, `run-dotnet-tests`, `update-agent-skills`, `template-sync`, `sync-cluster-policies`, `validate-go-project`) still use `app-id`/`APP_ID`. #226 shows `client-id` is the intended modern direction, so the suite should converge on it — but that's a multi-workflow change gated on knowing which org variables are provisioned, so it's filed separately rather than bundled here.
