### PR TITLE
fix(validate-go-project): only auto-commit linter fixes on pull_request events

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -163,6 +163,7 @@ jobs:
       - name: 💾 Commit and push applied linter fixes
         if: |
           steps.generate-token.outcome == 'success'
+          && github.event_name == 'pull_request'
           && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), github.event.pull_request.user.login)
           && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), inputs.pr-owner)
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
@@ -235,7 +236,7 @@ jobs:
       - name: 💾 Commit and push applied linter fixes
         if: |
           steps.generate-token.outcome == 'success'
-          && github.event_name != 'merge_group'
+          && github.event_name == 'pull_request'
           && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), github.event.pull_request.user.login)
           && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), inputs.pr-owner)
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
@@ -452,7 +453,7 @@ jobs:
       - name: Commit and push applied linter fixes
         if: |
           steps.generate-token.outcome == 'success'
-          && github.event_name != 'merge_group'
+          && github.event_name == 'pull_request'
           && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), github.event.pull_request.user.login)
           && !contains(fromJSON('["dependabot[bot]","dependabot","renovate[bot]","renovatebot","renovate"]'), inputs.pr-owner)
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`validate-go-project.yaml`'s three **"Commit and push applied linter fixes"** steps (go mod tidy, golangci-lint, mega-linter) committed auto-fixes and pushed them via `git-auto-commit-action` whenever they ran.

Callers (e.g. ksail) invoke this reusable workflow on **push to `main`**. On a push event there is no PR head branch, so the auto-commit pushed straight at the **protected default branch** and was rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
Error: Invalid status code: 1
```

That failed the entire `🧹 Lint - mega-linter` job (and `CI - Required Checks`), turning the **caller's `main` CI red** — observed live on [ksail run 27076054985](https://github.com/devantler-tech/ksail/actions/runs/27076054985) (sha `f887909`), where mega-linter found a pre-existing markdown-table drift under `VALIDATE_ALL_CODEBASE: true`, tried to commit it to `main`, and was rejected. Every subsequent push-to-`main` re-hit the same wall, so it does not self-heal.

The step comment already states the *intent* ("only pushes MegaLinter auto-fixes back to the **PR branch**") — the guards just didn't enforce it for `push`.

## Fix

Gate all three commit-and-push steps on `github.event_name == 'pull_request'` — the only event where a PR head branch exists to receive the fixes:

- **go mod tidy** step: had **no** event guard at all (ran on push *and* merge_group) → added.
- **golangci-lint** + **mega-linter** steps: replaced the partial `!= 'merge_group'` guard (which missed `push`) with `== 'pull_request'`.

On `push`/`merge_group` the linters still run and report status — they simply no longer attempt the invalid protected-branch push. Auto-fix-on-PR behaviour and the fork-PR fail-fast path (`generate-token.outcome != 'success'`) are unchanged.

## Impact

High-leverage shared-lib reliability fix — affects **every Go consumer** of `validate-go-project`. Resolves the recurring red `main` CI; ksail's `main` goes green once it bumps its pin to the release carrying this fix (the residual markdown drift becomes irrelevant — mega-linter reports success on push, it just no longer commits).

## Validation

- `actionlint` clean (0 issues) with the repo's documented `code-quality` permission ignore; the change is `+3 −2`, isolated to the three step `if:` blocks.
- No behaviour change on PR events (auto-commit still fires); merge_group lint jobs were already skipped at job level.