### PR TITLE
chore: remove orphaned .github/labels.yaml

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,6 +1,0 @@
-- name: blocked
-  color: "b60205"
-- name: released
-  color: "ededed"
-- name: expedite
-  color: "5d3fd3"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@ This file is the single canonical instructions file for the repository. It is re
 .github/
 ├── dependabot.yaml                        # Dependabot configuration (GitHub Actions)
 ├── fixtures/                              # Test fixtures consumed by test workflows
-├── labels.yaml                            # GitHub issue label definitions
 └── workflows/
     ├── ci.yaml                            # Reusable: continuous integration
     ├── create-release.yaml                # Reusable: semantic-release automation


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Removes `reusable-workflows/.github/labels.yaml` and its (now-stale) `AGENTS.md` directory-tree entry.

## Why — it is dead, divergent config

The repo carried its own `.github/labels.yaml` (`blocked`/`released`/`expedite`), but **nothing consumes it**. The daily `.sync-labels.yaml` caller invokes `devantler-tech/actions/sync-github-labels` with **no `config-file` override**, so per the action default it syncs from the **canonical remote** (`actions/.github/labels.yaml`) with `delete-other-labels: true`. The local file was therefore:

- **Unused** — never read as a config source.
- **Divergent** — only 3 labels with wrong colors (`blocked` `#b60205` vs canonical `#d93f0b`) and an `expedite` label that is **not** in the 21-label canonical set (the daily sync would delete `expedite` from this repo anyway).
- **Misleading** — `AGENTS.md` listed it as "GitHub issue label definitions", implying it is the source of truth when it is not.

## Portfolio consistency

A sweep of all public devantler-tech repos shows **only `actions` (the canonical source) and this repo** carried a local `.github/labels.yaml`; the other 8 (`ksail`, `go-template`, `dotnet-template`, `gitops-tenant-template`, `platform-template`, `homebrew-tap`, `skills`, `plugins`) correctly rely on the canonical remote with no local copy. This change brings reusable-workflows in line.

## Validation

- File deletion + one removed line inside the `AGENTS.md` fenced directory tree.
- `markdownlint-cli2 --config .markdownlint.json AGENTS.md`: no **new** findings (the single pre-existing MD032 nit is present on `main`, unrelated to this change).
- No dangling references remain — the only surviving `labels` mention in `AGENTS.md` is the `.sync-labels.yaml` **workflow** (which stays; it is the active caller).

## Type

`chore:` — config/docs cleanup, no reusable-workflow behaviour change, so it does not trigger a release.