### PR TITLE
ci: migrate create-github-app-token app-id to client-id input

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Least-privilege token scope: approving and enabling auto-merge on PRs.
           permission-contents: write

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Least-privilege token scope: checkout and open the sync PR.
           permission-contents: write

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ inputs.use-app-token }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           # Scope the token to exactly the caller repo (push the sync branch +

--- a/.github/workflows/update-agent-skills.yaml
+++ b/.github/workflows/update-agent-skills.yaml
@@ -81,7 +81,7 @@ jobs:
         if: ${{ inputs.use-app-token }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Scope the token to least privilege — exactly what this job needs
           # (checkout read + create-pull-request push/open) — instead of

--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Least-privilege token scope: only pushes linter auto-fixes back to the PR
           # branch (contents); the token is never used for PR/issue API calls.
@@ -209,7 +209,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Least-privilege token scope: only pushes linter auto-fixes back to the PR
           # branch (contents); the token is never used for PR/issue API calls.
@@ -418,7 +418,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Least-privilege token scope: only pushes MegaLinter auto-fixes back to the
           # PR branch (contents). MegaLinter's PR/issue reporting uses the default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Migrate the **direct** `actions/create-github-app-token` call sites from the deprecated `app-id` input to `client-id`. **Phase 1 of #308.**

`actions/create-github-app-token` deprecated `app-id` in favour of `client-id` (its `action.yml`: `app-id … deprecationMessage: "Use 'client-id' instead."`). It currently surfaces as a CI **warning** on every token-minting job across the portfolio (e.g. ksail PR CI: `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`). Deprecated inputs are eventually removed upstream, at which point every token-minting workflow would break — so migrate ahead of the removal. Reliability / anti-drift work under epic #305 (*reliable*).

## No provisioning needed

The org **already exposes `vars.APP_CLIENT_ID`** alongside `vars.APP_ID`, so this is a mechanical value swap. `create-release.yaml` already uses the `client-id` form, confirming it mints tokens correctly in practice.

## Scope — 7 direct call sites across 5 workflows

| File | Sites |
|---|---|
| `enable-auto-merge.yaml` | 1 |
| `sync-cluster-policies.yaml` | 1 |
| `template-sync.yaml` | 1 |
| `update-agent-skills.yaml` | 1 |
| `validate-go-project.yaml` | 3 |

Each: `app-id: ${{ vars.APP_ID }}` → `client-id: ${{ vars.APP_CLIENT_ID }}` on a `uses: actions/create-github-app-token@v3.2.0` step (`private-key` unchanged).

### Deliberately out of scope (Phase 2 — devantler-tech/actions#247)

`run-dotnet-tests.yaml` and `scan-for-todo-comments.yaml` forward `app-id` to **devantler-tech composite actions** (`run-dotnet-tests`, `create-issues-from-todos`) whose **own input is still named `app-id`**. Renaming the caller to `client-id` there would pass an unknown input and break token minting. Those two follow once the composites rename their input (breaking change, coordinated in #247). The #308 body has been corrected to reflect this (the original draft mis-listed them under Phase 1).

## Validation

`actionlint` clean on all 5 changed workflows. (The one pre-existing `actionlint` finding — `code-quality: write` unknown permission scope at `validate-go-project.yaml:599` — is unrelated to this change and present on `main`; it's the new GitHub Code Quality permission scope the bundled actionlint version doesn't yet recognise.)

Refs #308