### PR TITLE
ci(validate-go-project): skip golangci-lint network schema verify

### DIFF
--- a/.github/workflows/validate-go-project.yaml
+++ b/.github/workflows/validate-go-project.yaml
@@ -232,6 +232,11 @@ jobs:
         with:
           version: v2.11.4
           args: --fix
+          # Skip the action's `config verify` step: it fetches the golangci-lint
+          # JSONSchema over the network (golangci-lint.run), which intermittently
+          # times out ("context deadline exceeded") and fails the lint job. The
+          # config is still validated at runtime by `golangci-lint run`.
+          verify: false
 
       - name: 💾 Commit and push applied linter fixes
         if: |


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The shared `validate-go-project` reusable workflow's `🧹 Lint - golangci-lint`
job intermittently fails — observed repeatedly across the Go portfolio (ksail
most recently, on PR #5145) — with:

```
[.golangci.yml] validate: compile schema: failing loading
"https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json":
Get "...": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

`golangci/golangci-lint-action` runs `golangci-lint config verify` by default
(`verify: true`), which **fetches the config JSONSchema from `golangci-lint.run`
over the network**. That remote fetch times out non-deterministically, failing
the lint job even though the code and config are fine.

Because some consumers gate merges on this check (ksail's `main` ruleset has a
`code_quality` rule with `severity: all`), the flake repeatedly **blocks own
PRs from merging** and forces manual merge-main re-triggers. It has recurred
7+ times in the engineer's run history.

## Change

Set `verify: false` on the `golangci/golangci-lint-action` step. This skips
only the network-dependent schema-verification of `.golangci.yml`. The config
is **still validated at runtime** by `golangci-lint run`, so a genuinely broken
config still fails the job — just without a flaky remote fetch.

## Trade-off

We lose the action's early, schema-based validation of `.golangci.yml` (which
gives a slightly clearer message on a malformed config). Given the config is
team-maintained, version-pinned, and revalidated whenever golangci-lint is
bumped — and `golangci-lint run` catches real config errors anyway — removing
the recurring network-flaky failure is the better trade. Revert by dropping the
`verify: false` line if early schema validation is preferred.

Propagates to every Go repo consuming this reusable workflow (ksail,
go-template, …) once merged.
