### PR TITLE
docs: align AGENTS.md auth pattern with client-id migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,13 +101,13 @@ This repository uses **GitHub App tokens** (not `GITHUB_TOKEN`) for operations t
   uses: actions/create-github-app-token@<sha> # <version>
   id: generate-token
   with:
-    app-id: ${{ vars.APP_ID }}
+    client-id: ${{ vars.APP_CLIENT_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 
 The app credentials are:
 
-- `APP_ID` — stored as a repository/org variable
+- `APP_CLIENT_ID` — stored as a repository/org variable
 - `APP_PRIVATE_KEY` — stored as a repository/org secret
 
 ## Validation Commands


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The **Authentication Patterns** section of `AGENTS.md` still documents the **deprecated** `app-id` input and the `APP_ID` variable for `actions/create-github-app-token`:

```yaml
with:
  app-id: ${{ vars.APP_ID }}
  private-key: ${{ secrets.APP_PRIVATE_KEY }}
```

But **every direct `create-github-app-token` call site in this repo has already migrated to `client-id`** (PR #309 / issue #308 Phase 1) — all 5 workflows / 7 sites now use `client-id: ${{ vars.APP_CLIENT_ID }}`:

- `enable-auto-merge.yaml`, `sync-cluster-policies.yaml`, `template-sync.yaml`, `update-agent-skills.yaml`, `validate-go-project.yaml` (×3)

So the canonical pattern the doc teaches is the **one form the codebase no longer uses** — and the form upstream warns is deprecated and will eventually be removed. A future agent or contributor following `AGENTS.md` would reintroduce the deprecation warning.

## Change

Documentation-only. Update the `AGENTS.md` example and credential list to the non-deprecated, forward-compatible form the workflows actually use:

- `app-id: ${{ vars.APP_ID }}` → `client-id: ${{ vars.APP_CLIENT_ID }}`
- `` `APP_ID` — stored as a repository/org variable `` → `` `APP_CLIENT_ID` — … ``

No workflow/behaviour change. (The two **composite-forwarding** workflows — `run-dotnet-tests.yaml`, `scan-for-todo-comments.yaml` — still pass `app-id` to devantler-tech composite actions whose input is named `app-id`; that is Phase 2 / actions #247, out of scope here. They do not call the upstream action directly, so they are not the pattern this section documents.)

Anti-drift / agent-file stewardship under epic #305 (*reliable*): keep the steering docs in sync with what ships.