### PR TITLE
ci: grant template-sync App token the workflows scope

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -111,6 +111,17 @@ jobs:
           repositories: ${{ github.event.repository.name }},${{ steps.template.outputs.name }}
           permission-contents: write
           permission-pull-requests: write
+          # The template ships `.github/workflows/**`; pushing a sync commit that
+          # creates/updates a workflow file requires the `workflows` scope, else
+          # GitHub rejects the push ("refusing to allow a GitHub App to create or
+          # update workflow … without `workflows` permission"). This is the ONLY
+          # token path that can sync workflow changes — the `use-app-token: false`
+          # fallback (`GITHUB_TOKEN`) can never push workflow files regardless of
+          # job permissions (a GitHub safety restriction), so a template carrying
+          # workflow changes requires `use-app-token: true` (the default).
+          # NOTE: the App must have the **Workflows** repository permission granted
+          # for this scope to mint; without it `create-github-app-token` 422s.
+          permission-workflows: write
 
       - name: 📑 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `🔄 Template Sync` reusable workflow is **failing on `main`** for every consumer whose template diff touches `.github/workflows/**`. Observed today (2026-06-15) on:

- **wedding-app** — [run 27532735334](https://github.com/devantler-tech/wedding-app/actions/runs/27532735334)
- **ascoachingogvaner** — [run 27532233648](https://github.com/devantler-tech/ascoachingogvaner/actions/runs/27532233648)

Both fail identically at the push step:

```
! [remote rejected] chore/template-sync_… (refusing to allow a GitHub App to
create or update workflow `.github/workflows/cd.yaml` without `workflows` permission)
error: failed to push some refs
```

## Root cause

The `🔑 Generate GitHub App token` step scopes the minted token **down** to only `contents` + `pull-requests`:

```yaml
permission-contents: write
permission-pull-requests: write
```

The `gitops-tenant-template` upstream legitimately ships `.github/workflows/**` (this run's diff *creates* `sync-labels.yaml` + `validate-scaffold.yaml` and *modifies* `cd.yaml`). GitHub refuses any push that creates/updates a workflow file unless the pushing token carries the **`workflows`** scope — which the scope-down dropped. This is a **latent gap newly exposed** the first time a template diff included workflow-file changes; it affects **all** template-sync consumers, not just these two.

## Fix

Add `permission-workflows: write` to the App-token step (additive, one line + comment). `actionlint`-clean.

This is the **only** token path that can sync workflow changes: the `use-app-token: false` fallback uses `GITHUB_TOKEN`, which can *never* push workflow files regardless of job permissions (a GitHub safety restriction — `workflows` isn't even a valid `GITHUB_TOKEN` job-permission scope). So a template carrying workflow changes requires `use-app-token: true` (already the default). The comment documents this.

## ⚠️ Maintainer dependency — App permission

`create-github-app-token`'s `permission-*` inputs can only **scope down** from what the GitHub App is granted; they cannot grant more. For this token to mint with the `workflows` scope, the App behind `APP_CLIENT_ID` / `APP_PRIVATE_KEY` must have the **Workflows** repository permission granted (App settings → Permissions → *Workflows: Read and write*, then approve the installation permission update). **If it does not, `create-github-app-token` will 422** ("permissions requested are not granted") instead of the current push-rejection — net still blocked, but with a clearer signal. Please confirm/grant the Workflows permission; once granted (and this PR merged + consumers re-pinned to the new tag), the next template-sync run pushes cleanly.

## Validation

- `actionlint .github/workflows/template-sync.yaml` → clean.
- `template-sync` is a **non-gating** workflow (per AGENTS.md), so happy-path coverage is complete; no failure-mode self-test required.
- Backward-compatible: no input/output/secret interface change; purely widens the token scope.